### PR TITLE
Simplye(s) 319,284,285,315,313,295 and 276

### DIFF
--- a/Palace/Book/Models/TPPBookCoverRegistry.swift
+++ b/Palace/Book/Models/TPPBookCoverRegistry.swift
@@ -62,29 +62,39 @@ class TPPBookCoverRegistry {
   func thumbnailImagesForBooks(_ books: Set<TPPBook>, handler: @escaping (_ bookIdentifiersToImages: [String: UIImage]) -> Void) {
     var result: [String: UIImage] = [:] {
       didSet {
-        if books.count == result.keys.count {
+        if _books.count == result.keys.count {
           DispatchQueue.main.async {
             handler(result)
           }
         }
       }
     }
-    books.forEach { book in
+    
+    var _books : [TPPBook] = []
+    
+    for var b in books {
+      if !_books.contains(where: { book in
+        book.identifier == b.identifier
+      }) {
+        _books.append(b)
+      }
+    }
+
+    
+    _books.forEach { book in
+      print("thumbnail books \(book.identifier)")
       guard let thumbnailUrl = book.imageThumbnailURL else {
         result[book.identifier] = self.generateBookCoverImage(book)
         return
       }
       urlSession.dataTask(with: URLRequest(url: thumbnailUrl)) { imageData, response, error in
         if let imageData = imageData, let image = UIImage(data: imageData) {
-          DispatchQueue.main.async {
-            result[book.identifier] = image
-          }
+          result[book.identifier] = image
         } else {
-          DispatchQueue.main.async {
-            result[book.identifier] = self.generateBookCoverImage(book)
-          }
+          result[book.identifier] = self.generateBookCoverImage(book)
         }
       }.resume()
+      
     }
   }
   

--- a/Palace/Catalog/TPPCatalogNavigationController.m
+++ b/Palace/Catalog/TPPCatalogNavigationController.m
@@ -227,7 +227,6 @@
         }];
           if([accounts count] == 1){
             Account* account = [accounts firstObject];
-            //[account l]
             if (![NSThread isMainThread]) {
               dispatch_async(dispatch_get_main_queue(), ^{
                 [self welcomeScreenCompletionHandlerForAccount:account];
@@ -244,13 +243,8 @@
         [TPPConfiguration updateSavedeRegistryKey];
       }
       
-      //UINavigationController *navController;// = [[UINavigationController alloc] initWithRootViewController:welcomeScreenVC];
       
       if([accounts count] == 1) {
-        //navController = [[UINavigationController alloc] initWithRootViewController:onboardingVC];
-        
-        //[navController setModalPresentationStyle:UIModalPresentationFullScreen];
-        //[navController setModalTransitionStyle:UIModalTransitionStyleCrossDissolve];
         TPPRootTabBarController *vc = [TPPRootTabBarController sharedController];
         [vc safelyPresentViewController:onboardingVC animated:YES completion:nil];
         

--- a/Palace/MyBooks/MyBooks/BookCell/DownloadingBookCell.swift
+++ b/Palace/MyBooks/MyBooks/BookCell/DownloadingBookCell.swift
@@ -26,7 +26,7 @@ struct DownloadingBookCell: View {
       .frame(height: cellHeight)
       overlay
     }
-    .background(Color(TPPConfiguration.mainColor()))
+    //.background(Color(TPPConfiguration.mainColor()))
   }
 
   @ViewBuilder private var infoView: some View {
@@ -36,7 +36,7 @@ struct DownloadingBookCell: View {
       Text(model.authors)
         .font(Font(uiFont: UIFont.palaceFont(ofSize: 12)))
     }
-    .foregroundColor(Color(TPPConfiguration.backgroundColor()))
+    //.foregroundColor(Color(TPPConfiguration.backgroundColor()))
   }
   
   @ViewBuilder private var statusView: some View {
@@ -46,7 +46,7 @@ struct DownloadingBookCell: View {
         .horizontallyCentered()
         .padding(.top, 5)
         .font(Font(uiFont: UIFont.palaceFont(ofSize: 12)))
-        .foregroundColor(Color(TPPConfiguration.mainColor()))
+        //.foregroundColor(Color(TPPConfiguration.mainColor()))
     default:
       progressView
     }
@@ -56,7 +56,7 @@ struct DownloadingBookCell: View {
     HStack {
       Text(Strings.BookCell.downloading)
       ProgressView(value: progress, total: 1)
-        .progressViewStyle(LinearProgressViewStyle(tint: Color(TPPConfiguration.backgroundColor())))
+        /*.progressViewStyle(LinearProgressViewStyle(tint: Color(TPPConfiguration.backgroundColor())))*/
       Text("\(Int(progress * 100))%")
     }
     .font(Font(uiFont: UIFont.palaceFont(ofSize: 12)))
@@ -72,8 +72,8 @@ struct DownloadingBookCell: View {
       ForEach(model.buttonTypes, id: \.self) { type in
         ButtonView(
           title: type.localizedTitle.capitalized,
-          indicatorDate: model.indicatorDate(for: type),
-          backgroundFill: Color(TPPConfiguration.backgroundColor())) {
+          indicatorDate: model.indicatorDate(for: type)/*,
+          backgroundFill: Color(TPPConfiguration.backgroundColor())*/) {
           model.callDelegate(for: type)
         }
       }

--- a/Palace/Network/TPPNetworkExecutor.swift
+++ b/Palace/Network/TPPNetworkExecutor.swift
@@ -108,6 +108,8 @@ extension TPPNetworkExecutor: TPPRequestExecuting {
                   completion(result)
                 }
               }
+            }else {
+              completion(result)
             }
           }else{
             completion(result)
@@ -474,6 +476,9 @@ extension TPPNetworkExecutor {
           }
           
         }else{
+          TPPSignInBusinessLogic.getShared { logic in
+            logic?.performLogOut()
+          }
           print("authenticateWithToken error: \(String(describing: error?.localizedDescription)) data: \(String(describing: String(data:data!,encoding: .utf8)))")
         }
 

--- a/Palace/Settings/NewSettings/TPPSettingsView.swift
+++ b/Palace/Settings/NewSettings/TPPSettingsView.swift
@@ -27,13 +27,13 @@ struct TPPSettingsView: View {
 
   var body: some View {
 
-    if sideBarEnabled {
+    /*if sideBarEnabled {
       NavigationView {
         listView
       }.navigationViewStyle(.stack)
-    } else {
-      listView
-    }
+    } else {*/
+      listView.navigationBarItems(leading: leadingBarButton)
+    //}
   }
 
   @ViewBuilder private var listView: some View {
@@ -89,15 +89,7 @@ struct TPPSettingsView: View {
       row(title: DisplayStrings.libraries, index: 1, selection: self.$selectedView, destination: wrapper.anyView())
     }
   }
-  /*CellKindAdvancedSettings,
-  CellKindAgeCheck,
-  CellKindLogInSignOut,
-  CellKindPromptLogin,
-  CellKindSyncButton,
-  CellKindAbout,
-  CellKindPrivacyPolicy,
-  CellKindContentLicense,
-  CellReportIssue,*/
+
   @State private var toggleSyncBookmarks = false
   @State private var toggleLogoutWarning = false
   @State private var syncEnabled = AccountsManager.shared.accounts().first?.details?.syncPermissionGranted ?? false
@@ -124,6 +116,14 @@ struct TPPSettingsView: View {
             })
           }
         }
+    }
+  }
+  
+  @ViewBuilder private var leadingBarButton: some View {
+    Button {
+      TPPRootTabBarController.shared().showAndReloadCatalogViewController()
+    } label: {
+      ImageProviders.MyBooksView.myLibraryIcon
     }
   }
   
@@ -169,7 +169,27 @@ struct TPPSettingsView: View {
        Text(self.logoutText)
      }
      
-     row(title: DisplayStrings.registerPasskey, destination: PasskeyView(mode: .register, passKeyManager: PasskeyManager(AccountsManager.shared.currentAccount!.authenticationDocument!) ).anyView())
+     //row(title: DisplayStrings.registerPasskey, destination: PasskeyView(mode: .register, passKeyManager: PasskeyManager(AccountsManager.shared.currentAccount!.authenticationDocument!) ).anyView())
+     Button{
+       let passkey = PasskeyManager(AccountsManager.shared.currentAccount!.authenticationDocument!)
+       passkey.register("", TPPUserAccount.sharedAccount().authToken!) { registerToken in
+         if let token = registerToken, !token.isEmpty{
+           TPPNetworkExecutor.shared.authenticateWithToken(token) { status in
+
+           }
+           
+         }
+       }
+     } label: {
+       HStack{
+         Text(DisplayStrings.registerPasskey)
+         Spacer()
+         Image("ArrowRight")
+           .padding(.leading, 10)
+           .foregroundColor(Color(uiColor: .lightGray))
+       }
+
+     }
    }
   }
   
@@ -181,10 +201,7 @@ struct TPPSettingsView: View {
         passkey.login { loginToken in
           if let token = loginToken, !token.isEmpty{
             TPPNetworkExecutor.shared.authenticateWithToken(token) { status in
-              //authenticated = TPPUserAccount.sharedAccount().authToken != nil
-              /*DispatchQueue.main.async {
-                
-              }*/
+
             }
             
           }

--- a/Palace/Settings/TPPSettings.swift
+++ b/Palace/Settings/TPPSettings.swift
@@ -20,7 +20,7 @@ import Foundation
   }
 
   static let TPPAboutPalaceURLString = "http://thepalaceproject.org/"
-  static let TPPUserAgreementURLString = "https://www.kansalliskirjasto.fi/fi/e-kirjasto/e-kirjaston-saavutettavuusseloste"
+  static let TPPUserAgreementURLString = "https://www.kansalliskirjasto.fi/fi/e-kirjasto/e-kirjaston-kayttoehdot"
   static let TPPPrivacyPolicyURLString = "https://www.kansalliskirjasto.fi/fi/e-kirjasto/e-kirjaston-tietosuoja-ja-rekisteriseloste"
   static let TPPFeedbackURLString = "https://lib.e-kirjasto.fi/palaute"
   static let TPPAccessibilityURLString = "https://www.kansalliskirjasto.fi/fi/e-kirjasto/e-kirjaston-saavutettavuusseloste"

--- a/Palace/Utilities/Localization/Transifex/TransifexManager.swift
+++ b/Palace/Utilities/Localization/Transifex/TransifexManager.swift
@@ -8,10 +8,17 @@
 
 import Transifex
 
+class CustomLocaleProvider : TXCurrentLocaleProvider {
+    func currentLocale() -> String {
+      return Bundle.main.preferredLocalizations[0]
+    }
+}
+
 @objc class TransifexManager: NSObject {
   @objc static func setup() {
     let locales = TXLocaleState(sourceLocale: "en",
-                                appLocales: ["en", "fi", "sv"])
+                                appLocales: ["en", "fi", "sv"],
+                                currentLocaleProvider: CustomLocaleProvider())
 
     TXNative.initialize(
       locales: locales,


### PR DESCRIPTION
fixed Simplye(s) 319,284,285,315,313,295 and 276

When registering passkey it will now just pass an empty username and it seems to work. To get the current iCloud email app needs a new entitlement; but that's an easy fix.