### PR TITLE
Ekir 105 consisten statusbar

### DIFF
--- a/Palace/EkirjastoDigitalMagazine/DigitalMagazineBrowserViewController.swift
+++ b/Palace/EkirjastoDigitalMagazine/DigitalMagazineBrowserViewController.swift
@@ -51,9 +51,8 @@ class DigitalMagazineBrowserViewController: UIViewController, UITabBarController
   private func setupWebView() {
     webView.navigationDelegate = self
     webView.isOpaque = false
-    webView.backgroundColor = .clear
+    webView.backgroundColor = TPPConfiguration.backgroundColor()
     webView.addObserver(self, forKeyPath: "URL", options: .new, context: nil)
-    webView.navigationDelegate = self
     
 #if DEBUG
     if #available(iOS 16.4, *) {
@@ -65,13 +64,22 @@ class DigitalMagazineBrowserViewController: UIViewController, UITabBarController
     
     // use auto-layout
     webView.translatesAutoresizingMaskIntoConstraints = false
-    let lauoutGuide = view.safeAreaLayoutGuide
+    let layoutGuide = view.safeAreaLayoutGuide
     NSLayoutConstraint.activate([
-      webView.topAnchor.constraint(equalTo: lauoutGuide.topAnchor, constant: 0.0),
-      webView.leadingAnchor.constraint(equalTo: lauoutGuide.leadingAnchor, constant: 0.0),
-      webView.trailingAnchor.constraint(equalTo: lauoutGuide.trailingAnchor, constant: 0.0),
-      webView.bottomAnchor.constraint(equalTo: lauoutGuide.bottomAnchor, constant: 0.0),
+      webView.topAnchor.constraint(equalTo: layoutGuide.topAnchor, constant: 0.0),
+      webView.leadingAnchor.constraint(equalTo: layoutGuide.leadingAnchor, constant: 0.0),
+      webView.trailingAnchor.constraint(equalTo: layoutGuide.trailingAnchor, constant: 0.0),
+      webView.bottomAnchor.constraint(equalTo: layoutGuide.bottomAnchor, constant: 0.0),
     ])
+    
+    // draw statusbar, as it gets black
+    guard let windowScene = UIApplication.shared.connectedScenes.first as? UIWindowScene,
+          let statusBarFrame = windowScene.statusBarManager?.statusBarFrame else {
+      return
+    }
+    let statusBarView = UIView(frame: statusBarFrame)
+    statusBarView.backgroundColor = TPPConfiguration.backgroundColor() // this
+    view.addSubview(statusBarView)
   }
   
   override func viewWillAppear(_ animated: Bool) {

--- a/Palace/EkirjastoDigitalMagazine/DigitalMagazineBrowserViewController.swift
+++ b/Palace/EkirjastoDigitalMagazine/DigitalMagazineBrowserViewController.swift
@@ -49,37 +49,32 @@ class DigitalMagazineBrowserViewController: UIViewController, UITabBarController
   }
   
   private func setupWebView() {
+    // Configure view
+    view.backgroundColor = TPPConfiguration.backgroundColor()
+    view.addSubview(webView)
+    
+    // Configure WebView
     webView.navigationDelegate = self
     webView.isOpaque = false
     webView.backgroundColor = TPPConfiguration.backgroundColor()
     webView.addObserver(self, forKeyPath: "URL", options: .new, context: nil)
+    
+    // Use auto-layout
+    webView.translatesAutoresizingMaskIntoConstraints = false
+    
+    // Activate constraints
+    NSLayoutConstraint.activate([
+      webView.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor),
+      webView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+      webView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+      webView.bottomAnchor.constraint(equalTo: view.bottomAnchor)
+    ])
     
 #if DEBUG
     if #available(iOS 16.4, *) {
       webView.isInspectable = true
     }
 #endif
-    
-    view.addSubview(webView)
-    
-    // use auto-layout
-    webView.translatesAutoresizingMaskIntoConstraints = false
-    let layoutGuide = view.safeAreaLayoutGuide
-    NSLayoutConstraint.activate([
-      webView.topAnchor.constraint(equalTo: layoutGuide.topAnchor, constant: 0.0),
-      webView.leadingAnchor.constraint(equalTo: layoutGuide.leadingAnchor, constant: 0.0),
-      webView.trailingAnchor.constraint(equalTo: layoutGuide.trailingAnchor, constant: 0.0),
-      webView.bottomAnchor.constraint(equalTo: layoutGuide.bottomAnchor, constant: 0.0),
-    ])
-    
-    // draw statusbar, as it gets black
-    guard let windowScene = UIApplication.shared.connectedScenes.first as? UIWindowScene,
-          let statusBarFrame = windowScene.statusBarManager?.statusBarFrame else {
-      return
-    }
-    let statusBarView = UIView(frame: statusBarFrame)
-    statusBarView.backgroundColor = TPPConfiguration.backgroundColor() // this
-    view.addSubview(statusBarView)
   }
   
   override func viewWillAppear(_ animated: Bool) {


### PR DESCRIPTION
**What's this do?**
This fix configures webview constrains and safearea to properly show status bar in magazine browser view.
Statusbar was always black, and did not take appearance setting (light/dark) into account. 

**Did someone actually run this code to verify it works?**
Tested with simulator:
iPhone 11 17.5
iPhone 15
iPhone Xs
iPad Air 11' m2

iPhone 6s 15.5