### PR TITLE
Ekir 241 invite dependents

### DIFF
--- a/Palace.xcodeproj/project.pbxproj
+++ b/Palace.xcodeproj/project.pbxproj
@@ -1198,6 +1198,8 @@
 		E6207B652118973800864143 /* TPPAppTheme.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6207B642118973800864143 /* TPPAppTheme.swift */; };
 		E63F2C6C1EAA81B3002B6373 /* ExtendedNavBarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E63F2C6B1EAA81B3002B6373 /* ExtendedNavBarView.swift */; };
 		E65977C51F82AC91003CD6BC /* TPP_Launch_Screen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = E65977C41F82AC91003CD6BC /* TPP_Launch_Screen.storyboard */; };
+		E6602BC52C64DCB200B1212D /* DependentsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6602BC42C64DCB200B1212D /* DependentsView.swift */; };
+		E6602BC62C64DCB200B1212D /* DependentsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6602BC42C64DCB200B1212D /* DependentsView.swift */; };
 		E66A6C441EAFB63300AA282D /* TPPBookButtonsView.m in Sources */ = {isa = PBXBuildFile; fileRef = E66A6C431EAFB63300AA282D /* TPPBookButtonsView.m */; };
 		E671FF7D1E3A7068002AB13F /* TPPNetworkQueue.swift in Sources */ = {isa = PBXBuildFile; fileRef = E671FF7C1E3A7068002AB13F /* TPPNetworkQueue.swift */; };
 		E683953B217663B100371072 /* TPPFacetViewDefaultDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = E683953A217663B100371072 /* TPPFacetViewDefaultDataSource.swift */; };
@@ -2101,6 +2103,7 @@
 		E6207B642118973800864143 /* TPPAppTheme.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TPPAppTheme.swift; sourceTree = "<group>"; };
 		E63F2C6B1EAA81B3002B6373 /* ExtendedNavBarView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ExtendedNavBarView.swift; sourceTree = "<group>"; };
 		E65977C41F82AC91003CD6BC /* TPP_Launch_Screen.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = TPP_Launch_Screen.storyboard; sourceTree = "<group>"; };
+		E6602BC42C64DCB200B1212D /* DependentsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DependentsView.swift; sourceTree = "<group>"; };
 		E66A6C421EAFB63300AA282D /* TPPBookButtonsView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TPPBookButtonsView.h; sourceTree = "<group>"; };
 		E66A6C431EAFB63300AA282D /* TPPBookButtonsView.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = TPPBookButtonsView.m; sourceTree = "<group>"; };
 		E66AE32F1DC0FCFC00124AE2 /* TPPCirculationAnalytics.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TPPCirculationAnalytics.swift; sourceTree = "<group>"; };
@@ -3645,6 +3648,7 @@
 				E5B2B8D9275952EC00150ED4 /* TPPSettingsView.swift */,
 				E5B2B8DC2759552F00150ED4 /* TPPSettingsViewController.swift */,
 				E69E21B62C638C0D007B26EC /* PreferencesView.swift */,
+				E6602BC42C64DCB200B1212D /* DependentsView.swift */,
 			);
 			path = NewSettings;
 			sourceTree = "<group>";
@@ -4837,6 +4841,7 @@
 				331264152A287F53006BA87D /* TPPSettingsView.swift in Sources */,
 				3375701E2A2F685500547CE1 /* TPPSecrets.swift in Sources */,
 				331264162A287F53006BA87D /* TPPOPDSFeed.m in Sources */,
+				E6602BC52C64DCB200B1212D /* DependentsView.swift in Sources */,
 				331264172A287F53006BA87D /* TPPOPDSLink.m in Sources */,
 				33FCF7F92AC4595E008E3B72 /* URL+Extensions.swift in Sources */,
 				331264182A287F53006BA87D /* TPPSettingsViewController.swift in Sources */,
@@ -5395,6 +5400,7 @@
 				5DD5674522B303DF001F0C83 /* TPPDeveloperSettingsTableViewController.swift in Sources */,
 				E5AD65E12684FDA300C62951 /* TPPAccountListDataSource.swift in Sources */,
 				E5EFDE7C298C4F8000258CA3 /* BookCellModel.swift in Sources */,
+				E6602BC62C64DCB200B1212D /* DependentsView.swift in Sources */,
 				2D754BC22002F1B10061D34F /* TPPOPDSIndirectAcquisition.m in Sources */,
 				21E35FC3268CC8AC00066F9D /* AdobeContentProtectionService.swift in Sources */,
 				21C7B87E25AE1DBA000E8BF3 /* LibraryServiceError.swift in Sources */,

--- a/Palace/Accounts/User/TPPUserAccount.swift
+++ b/Palace/Accounts/User/TPPUserAccount.swift
@@ -17,6 +17,7 @@ private enum StorageKey: String {
   case credentials = "TPPAccountCredentialsKey"
   case authDefinition = "TPPAccountAuthDefinitionKey"
   case cookies = "TPPAccountAuthCookiesKey"
+  case patronPermanentId = "TPPPatronPermanentId"
 
   func keyForLibrary(uuid libraryUUID: String?) -> String {
     guard
@@ -65,6 +66,7 @@ class TPPUserAccountAuthentication: ObservableObject {
         StorageKey.credentials: _credentials,
         StorageKey.authDefinition: _authDefinition,
         StorageKey.cookies: _cookies,
+        StorageKey.patronPermanentId: _patronPermanentId,
 
         // legacy
         StorageKey.barcode: _barcode,
@@ -149,6 +151,7 @@ class TPPUserAccountAuthentication: ObservableObject {
             _credentials.write(credentials)
             _authToken.write(nil)
           }
+        
         }
       }
 
@@ -253,6 +256,9 @@ class TPPUserAccountAuthentication: ObservableObject {
     .keyForLibrary(uuid: libraryUUID)
     .asKeychainCodableVariable(with: accountInfoLock)
   private lazy var _cookies: TPPKeychainVariable<[HTTPCookie]> = StorageKey.cookies
+    .keyForLibrary(uuid: libraryUUID)
+    .asKeychainVariable(with: accountInfoLock)
+  private lazy var _patronPermanentId: TPPKeychainVariable<String> = StorageKey.patronPermanentId
     .keyForLibrary(uuid: libraryUUID)
     .asKeychainVariable(with: accountInfoLock)
 
@@ -408,6 +414,9 @@ class TPPUserAccountAuthentication: ObservableObject {
     return nil
   }
   
+  var patronPermantId: String? { _patronPermanentId.read() }
+
+  
   var patronFullName: String? {
     if let patron = patron,
       let name = patron["name"] as? [String:String]
@@ -520,6 +529,12 @@ class TPPUserAccountAuthentication: ObservableObject {
     _deviceID.write(id)
     notifyAccountDidChange()
   }
+  
+  @objc(setPatronPermanentId:)
+  func setPatronPermanentId(_ identifier: String) {
+    _patronPermanentId.write(identifier)
+    print("TPPUserAccount patronPermanentId has been set")
+  }
     
   // MARK: - Remove
 
@@ -542,6 +557,7 @@ class TPPUserAccountAuthentication: ObservableObject {
         _barcode.write(nil)
         _pin.write(nil)
         _authToken.write(nil)
+        _patronPermanentId.write(nil)
 
         notifyAccountDidChange()
         

--- a/Palace/Settings/NewSettings/DependentsView.swift
+++ b/Palace/Settings/NewSettings/DependentsView.swift
@@ -7,19 +7,55 @@
 
 import SwiftUI
 
+struct Dependent: Codable, Identifiable, Hashable {
+    let id: String
+    let firstName: String
+    let lastName: String
+
+  private enum CodingKeys: String, CodingKey {
+      case govId
+      case firstName
+      case lastName
+  }
+
+  init(from decoder: Decoder) throws {
+      let container = try decoder.container(keyedBy: CodingKeys.self)
+      id = try container.decode(String.self, forKey: .govId)
+      firstName = try container.decode(String.self, forKey: .firstName)
+      lastName = try container.decode(String.self, forKey: .lastName)
+  }
+  
+  func encode(to encoder: Encoder) throws {
+      var container = encoder.container(keyedBy: CodingKeys.self)
+      try container.encode(id, forKey: .govId)
+      try container.encode(firstName, forKey: .firstName)
+      try container.encode(lastName, forKey: .lastName)
+  }
+}
+
+struct LoikkaResponse: Codable {
+    let items: [Dependent]
+}
+
+
 struct DependentsView: View {
   typealias tsx = Strings.Settings
+  typealias tsxgeneric = Strings.Generic
   @State private var inputEmail: String = ""
   @State private var isEmailValid: Bool = false
-  var dependents = ["Select a Dependent", "No Dependents Found"]
-  @State private var selectedDependent = ""
-  @State private var circulationToken: String = ""
+  @State private var ekirjastoToken: String = ""
   @State var authDoc : OPDS2AuthenticationDocument? = nil
-  @State private var LoikkaDependents: [String] = []
+  @State private var fetchedDependents: [Dependent] = []
+  @State private var showPicker: Bool = false
+  @State private var delegateToken = TPPUserAccount.sharedAccount().authToken!
+  @State private var id = ""
+  @State private var alertMessage = ""
+  @State private var showAlert = false
+  @State private var showSuccess = false
+  @State private var isLoading: Bool = false
+  @State private var isLoadingSend: Bool = false
 
-
-  @State private var isDependentsFetched: Bool = false
-
+  
   var body: some View {
     List{
       Section {
@@ -32,81 +68,97 @@ struct DependentsView: View {
             .frame(width: 200)
         }
       }
-      Button{
-        var res = getDependents()
-      } label: {
-        HStack{
-          Text(tsx.getDependents)
-          Spacer()
-          Image("ArrowRight")
-            .padding(.leading, 10)
-            .foregroundColor(Color(uiColor: .lightGray))
-        }
-      }
-      //TODO: picker here
-      if isDependentsFetched { // Once the request to Loikka has been made, this section becomes visible
-        VStack{
-          Spacer()
-          if LoikkaDependents.isEmpty {
-            Text(tsx.noDependents).tag(tsx.noDependents)
-            
-          } else {
-            Picker(tsx.select, selection: $selectedDependent) {
-              Text(tsx.selectADependent)
-                ForEach(LoikkaDependents, id: \.self) { dependent in
-                  Text(dependent).tag(dependent)
-                  }
+      
+      Section {
+        VStack {
+          // This is where it starts, the user taps the button to get their children/dependents
+          Button{
+            isLoading = true
+            getDependents()
+          } label: {
+            HStack{
+              Text(tsx.getDependents)
+              Spacer()
+              Image("ArrowRight")
+                .padding(.leading, 10)
+                .foregroundColor(Color(uiColor: .lightGray))
             }
           }
-        }
-        
-        if !selectedDependent.isEmpty {
-          VStack {
-            TextField(
-              tsx.enterEmail,
-              text: $inputEmail
-            )
-            .keyboardType(.emailAddress)
-            .autocapitalization(.none)
-            .onChange(of: inputEmail) { newValue in isEmailValid = validate(newValue)}
-            
-            Button {
-              print("button pressed")
-            } label: {
-              HStack {
-                Text(tsx.sendButton)
-                  .foregroundColor(isEmailValid ? .black : .gray)
+          if isLoading {
+            ProgressView()
+          }
+          
+          Section {
+            VStack {
+              // Once the request to Loikka has been made, this section becomes visible
+              if showPicker {
                 
-                Image("ArrowRight")
-                  .padding(.leading, 10)
-                  .foregroundColor(Color(uiColor: .lightGray))
+                if fetchedDependents.isEmpty {
+                  Text(tsx.noDependents).tag(tsx.noDependents)
+                  
+                } else {
+                  Picker(tsx.select, selection: $id) {
+                    Text(tsx.selectADependent).tag(tsx.selectADependent)
+                    // Show the name of the fetched dependents and store their id
+                    ForEach(fetchedDependents, id: \.id) { dependent in
+                      Text(dependent.firstName).tag(dependent.id)
+                    }
+                  }
+                  
+                }
               }
-              .disabled(!isEmailValid)
+            }
+            .alert(isPresented: $showAlert) {
+              Alert(title: Text(tsxgeneric.error), message: Text(alertMessage), dismissButton: .default(Text(tsxgeneric.ok)))
             }
           }
-            
-//            Button {
-//            } label: {
-//                if validate(inputEmail) {
-//                    HStack {
-//                        Text(tsx.sendButton)
-//                        Spacer()
-//                        Image("ArrowRight")
-//                            .padding(.leading, 10)
-//                            .foregroundColor(Color(uiColor: .lightGray))
-//                    }
-//                } else {
-//                  Text("Not a valid email")
-//                }
-//            } // ends label
-//          }
         }
-
-        
-        
       }
-    }
+      
+        // If the user has selected a dependent, we show them an email text field
+        if id != "" {
+            VStack {
+              Text(tsx.guideText)
+                .foregroundStyle(Color(uiColor: .lightGray))
+                .font(.subheadline)
+                .padding()
+                .frame(maxWidth: .infinity, alignment: .leading)
+              TextField(tsx.enterEmail, text: $inputEmail)
+                .padding()
+                .border(Color(uiColor: .lightGray), width: 1)
+                .cornerRadius(3)
+
+              Button {
+                sendInviteToDependent(dependentId: id)
+              } label: {
+                HStack {
+                  Text(tsx.sendButton)
+                  Image("ArrowRight")
+                    .padding(.leading, 10)
+                    .foregroundColor(Color(uiColor: .lightGray))
+                }
+                .padding(10)
+              }
+
+            }
+            .alert(isPresented: $showAlert) {
+              Alert(title: Text(tsxgeneric.error), message: Text(alertMessage), dismissButton: .default(Text(tsxgeneric.ok)))
+            }
+            .alert(isPresented: $showSuccess) {
+              Alert(title: Text(tsx.successButton), message: Text(alertMessage), dismissButton: .default(Text(tsxgeneric.ok)))
+            }
+          
+          if isLoadingSend {
+            VStack {
+              ProgressView()
+            }
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+          }
+        }
+      }
   }
+  
+
   
   func fetchAuthDoc(completion: @escaping (_ doc: (OPDS2AuthenticationDocument?))->Void){
     if let currentAccount = AccountsManager.shared.currentAccount {
@@ -130,153 +182,255 @@ struct DependentsView: View {
     }
   }
   
-  func makeGetRequestWithAccessToken(url: String, accessToken: String, completion: @escaping (Result<String, Error>) -> Void) {
-    let url = URL(string: url)!
-    var request = URLRequest(url: url)
-    request.httpMethod = "GET"
-    request.setValue("Bearer \(accessToken)", forHTTPHeaderField: "Authorization")
+  enum HTTPError: Error {
+      case serverError
+      case unknown
     
-    let task = URLSession.shared.dataTask(with: request) { data, response, error in
-        if let error = error {
-            print("Request error: ", error)
-            completion(.failure(error))
-            return
-        }
-        
-        guard let httpResponse = response as? HTTPURLResponse else {
-            let responseError = NSError(domain: "HTTP", code: 0, userInfo: [NSLocalizedDescriptionKey: "Invalid HTTP response"])
-            completion(.failure(responseError))
-            return
-        }
-      print("status code: \(httpResponse.statusCode)")
-        if httpResponse.statusCode == 200 {
-            guard let data = data else {
-                let dataError = NSError(domain: "Data", code: 0, userInfo: [NSLocalizedDescriptionKey: "Invalid data"])
-                completion(.failure(dataError))
-                return
-            }
-            
-            if let responseString = String(data: data, encoding: .utf8) {
-                DispatchQueue.main.async {
-                    completion(.success(responseString))
-                }
-            } else {
-                let dataParsingError = NSError(domain: "Data", code: 0, userInfo: [NSLocalizedDescriptionKey: "Data parsing error"])
-                completion(.failure(dataParsingError))
-            }
-        } else {
-            let statusCodeError = NSError(domain: "HTTP", code: httpResponse.statusCode, userInfo: [NSLocalizedDescriptionKey: "Invalid status code"])
-            completion(.failure(statusCodeError))
+    func errorMessage() -> String {
+        switch self {
+        case .serverError:
+            return tsx.errorFromServer
+        case .unknown:
+          return tsx.errorInCreation
         }
     }
-    task.resume()
   }
-  
-  func getCirculationToken(accessToken: String, completion: @escaping (Result<String, Error>) -> Void) {
-    
-    print("Start circulation request: \(accessToken)")
-    let url = "https://lib-dev.e-kirjasto.fi/ekirjasto/ekirjasto_token?provider=E-kirjasto+provider+for+circulation+manager"
 
-    makeGetRequestWithAccessToken(url: url, accessToken: accessToken) { result in
-      switch result {
-      case .success(let response):
-        print("Circulation response: \(response)")
-        if let data = response.data(using: .utf8) {
-            do {
-                if let json = try JSONSerialization.jsonObject(with: data, options: []) as? [String: Any],
-                   let token = json["token"] as? String {
+  
+  /// A general http request function that returns the response when the request has been successful and handles different unsuccessful responses.
+  /// - Parameters:
+  ///   - httpMethod: String: Http method to be used, e.g. "GET"
+  ///   - url: String: The URL of the request
+  ///   - accessToken: String: Bearer token to be used for the request
+  ///   - jsonRequestBody: Optional JSON data: For POST requests, a JSON request body
+  ///   - completion: Returns the response
+  func createHTTPRequest(httpMethod: String, url: String, accessToken: String, jsonRequestBody: Data? = nil, contentType: String? = nil, completion: @escaping (Result<Data, HTTPError>) -> Void) {
+      // Set up the http request
+      let url = URL(string: url)!
+      var request = URLRequest(url: url)
+      request.httpMethod = httpMethod
+      request.setValue("Bearer \(accessToken)", forHTTPHeaderField: "Authorization")
+      
+      if let contentTypeString = contentType {
+        request.setValue(contentTypeString, forHTTPHeaderField: "Content-Type")
+    }
+      if let requestBody = jsonRequestBody {
+        request.httpBody = requestBody
+    }
+      // Execute the request and handle errors based on the response status code.
+      let task = URLSession.shared.dataTask(with: request) { data, response, error in
+        print("HTTP request to: \(request)")
+          if let error = error {
+            self.showAlert = true
+            self.alertMessage = HTTPError.unknown.errorMessage()
+              print("Request error: \(error)")
+            completion(.failure(.unknown))
+              return
+          }
+          
+          guard let httpResponse = response as? HTTPURLResponse else {
+            self.showAlert = true
+            self.alertMessage = HTTPError.unknown.errorMessage()
+            print("alerts: \(self.alertMessage), \(self.showAlert)")
+            completion(.failure(.unknown))
+            return
+          }
+          
+          switch httpResponse.statusCode {
+          case 200...299:
+              if let data = data {
+                // Successful response returns the data
+                  completion(.success(data))
+              } else {
+                // If data is nil, return an appropriate error
+                self.showAlert = true
+                self.alertMessage = HTTPError.unknown.errorMessage()
+                print("alerts: \(self.alertMessage), \(self.showAlert)")
+                completion(.failure(.unknown))
+              }
+          default:
+            self.showAlert = true
+            self.alertMessage = HTTPError.serverError.errorMessage()
+            print("alerts: \(self.alertMessage), \(self.showAlert)")
+            print("HTTP status code: \(httpResponse.statusCode)")
+            // Use a default error for non-2xx status codes
+            completion(.failure(.serverError))
+          }
+      }
+      task.resume()
+  }
+
+  
+/// Function that fetches a user's e-kirjasto token from e-kirjasto circulation backend. A successful request returns the token.
+/// - Parameters:
+///   - accessToken: String: A delegate token that allows making requests to e-kirjasto backend.
+  func getEkirjastoToken(accessToken: String, completion: @escaping (Result<String, Error>) -> Void) {
+    
+    let delegateToken = self.delegateToken
+    print("Start circulation request with: \(delegateToken)")
+    let url = "https://lib-dev.e-kirjasto.fi/ekirjasto/ekirjasto_token?provider=E-kirjasto+provider+for+circulation+manager"
+    
+      createHTTPRequest(httpMethod: "GET", url: url, accessToken: delegateToken) { result in
+          switch result {
+          case .success(let data):
+              do {
+                if let jsonResponse = try JSONSerialization.jsonObject(with: data, options: []) as? [String: Any],
+                   let token = jsonResponse["token"] as? String {
+                    print("We got this token from circulation: \(token)")
                     completion(.success(token))
                 } else {
-                    let parsingError = NSError(domain: "JSON", code: 0, userInfo: [NSLocalizedDescriptionKey: "Invalid JSON format or missing 'token'"])
-                    completion(.failure(parsingError))
+                  let parsingError = NSError(domain: "", code: 0, userInfo: [NSLocalizedDescriptionKey: "JSON response does not contain the expected data"])
+                  completion(.failure(parsingError))
                 }
-            } catch {
+              } catch {
+                  print("Decoding error: \(error)")
                 completion(.failure(error))
-            }
-        } else {
-            let dataError = NSError(domain: "Data", code: 0, userInfo: [NSLocalizedDescriptionKey: "Failed to convert response string to data"])
-            completion(.failure(dataError))
-        }
-
-      case .failure(let error):
-        print("Circulation Error: \(error)")
-        completion(.failure(error))
+              }
+          case .failure(let error):
+              completion(.failure(error))
+          }
       }
-    }
   }
   
-  
-  func getDependentsRequest(accessToken: String, patronPermanantId: String, completion: @escaping (Result<[String], Error>) -> Void) {
+  /// Function that makes a request to e-kirjasto authentication service using a valid e-kirjasto token and the user's (patron's) permanent id in e-kirjasto services. A successful request returns a list of dependents.
+  /// - Parameters:
+  ///   - accessToken: String: A valid e-kirjasto token
+  ///   - patronPermanantId:  String: The user's permanent id in the e-kirjasto services.
+  ///   - completion: List: A list of decoded Depenedent objects is returned.
+  func getDependentsRequest(accessToken: String, patronPermanantId: String, completion: @escaping (Result<[Dependent], Error>) -> Void) {
    
     print("Start Dependents request: \(accessToken)")
     let url = "\("https://e-kirjasto.loikka.dev/v1/identities/")\(patronPermanantId)\("/relations")"
-
-    makeGetRequestWithAccessToken(url: url, accessToken: accessToken) { result in
-      switch result {
-      case .success(let response):
-        print("Loikka response: \(response)")
-        if let data = response.data(using: .utf8) {
-            do {
-                if let json = try JSONSerialization.jsonObject(with: data, options: []) as? [String: Any],
-                   let items = json["items"] as? [[String: Any]] {
-                    let firstNames = items.compactMap { $0["firstName"] as? String }
-                    completion(.success(firstNames))
-                } else {
-                    let parsingError = NSError(domain: "JSON", code: 0, userInfo: [NSLocalizedDescriptionKey: "Invalid JSON format or missing 'items'"])
-                    completion(.failure(parsingError))
+  
+    createHTTPRequest(httpMethod: "GET", url: url, accessToken: accessToken) { result in
+            switch result {
+            case .success(let response):
+                do {
+                  // Decode the json reponse into Depenedent objects and return them as a list
+                    let decodedData = try JSONDecoder().decode(LoikkaResponse.self, from: response)
+                    print("Dependents: \(decodedData.items)")
+                    completion(.success(decodedData.items))
+                } catch {
+                  let parsingError = NSError(domain: "", code: 0, userInfo: [NSLocalizedDescriptionKey: "JSON response does not contain the expected data"])
+                  completion(.failure(parsingError))
                 }
-            } catch {
-                completion(.failure(error))
+      
+            case .failure(let error):
+              completion(.failure(error))
             }
-        } else {
-            let dataError = NSError(domain: "Data", code: 0, userInfo: [NSLocalizedDescriptionKey: "Failed to convert response string to data"])
-            completion(.failure(dataError))
-        }
-
-      case .failure(let error):
-        print("Dependents Error: \(error)")
-        completion(.failure(error))
-      }
     }
   }
   
-
+  
+  /// Function that takes the signed in user's stored delegate token (=circulation token) to make a request to circulation backend to fetch the latest e-kirjasto token. Using the fetched e-kirjasto token, a new request is made to the authentication servive to get a list of the user's dependents. If a user does not have any dependents, an empty list is returned.
   func getDependents(){
     print("Getting dependents...")
     let patronPermanentId = TPPUserAccount.sharedAccount().patronPermantId!
     print("Permanent id: " + patronPermanentId)
-    let currentEkirjastoToken = TPPUserAccount.sharedAccount().authToken!
-    print("Ekirajsto token: \(currentEkirjastoToken)")
-    getCirculationToken(accessToken: currentEkirjastoToken) { circulationResult in
+    print("E-kirjasto token: \(self.delegateToken)")
+    
+    // First use the stored delegate token to get a valid e-kirjasto token
+    getEkirjastoToken(accessToken: self.delegateToken) { circulationResult in
         switch circulationResult {
-        case .success(let circulationToken):
-            getDependentsRequest(accessToken: circulationToken, patronPermanantId: patronPermanentId) { dependentsResult in
-                switch dependentsResult {
-                case .success(let dependents):
-                    print("Dependents: \(dependents)")
-                  self.LoikkaDependents = dependents
-                  self.isDependentsFetched = true
-                case .failure(let error):
-                  print("error: \(error)")
-                }
+        case .success(let ekirjastoToken):
+          // store the e-kirjasto token to properties for later use.
+          self.ekirjastoToken = ekirjastoToken
+            
+            // Get the user's dependents now that we have an e-kirjasto token
+          getDependentsRequest(accessToken: ekirjastoToken, patronPermanantId: patronPermanentId) { dependentsResult in
+                  switch dependentsResult {
+                    case .success(let dependents):
+                      self.showPicker = true
+                      self.fetchedDependents = dependents
+                    if let firstDependent = fetchedDependents.first {
+                        print(firstDependent.firstName)
+                      // Store the first dependent's id to be used in the view's picker
+                      self.id = firstDependent.id
+                      self.isLoading = false
+                    } else {
+                        // fetchedDependents on tyhjä
+                        print("No dependents available")
+                    }
+                    case .failure(let error):
+                      print("error: \(error)")
+                  }
             }
         case .failure(let error):
           print("error: \(error)")
         }
     }
-
-    //TODO: get method to fetch dependents from Loikka
-    //TODO: to put in a picker programmatically and
-    //TODO: to show user input for dependent email
-    
-    //TODO: fetch account id
-    
-    //finally return
   }
   
+  /// Function that encodes the selected dependent's information to a JSON request body and makes a post request to the authentication service invite endpoint.
+  /// - Parameter dependentId: String: Selected dependent's id
+  func sendInviteToDependent(dependentId: String) {
+    print("Start Dependent invite function")
+    
+    // Check here that the typed in email is valid
+    let emailValid = validate(self.inputEmail)
+    if !emailValid {
+      self.alertMessage = tsx.incorrectEmail
+      self.showAlert = true
+    } else {
+      
+      var jsonData: Data?
+      // Find the Dependent with the matching id (user selected it in the picker)
+      if let dependentObject = self.fetchedDependents.first(where: { $0.id == dependentId }) {
+        print("Found dependent: \(dependentObject)")
+        
+        // Map the Dependent's properties to a dictionary. Role is always "customer".
+        let dictionary: [String: String] = [
+          "firstName": dependentObject.firstName,
+          "lastName": dependentObject.lastName,
+          "govId": dependentObject.id,
+          "email": self.inputEmail,
+          "locale": "fi",
+          "role": "customer"
+        ].compactMapValues { $0 }
+        
+        // Encode the dictionary to JSON
+        do {
+          let encodedData = try JSONEncoder().encode(dictionary)
+          jsonData = encodedData
+        } catch {
+          print("Error encoding dictionary to JSON: \(error)")
+        }
+      } else {
+        print("No matching dependent: \(dependentId)!")
+      }
+      
+      let url = "https://e-kirjasto.loikka.dev/v1/identities/invite"
+      let appJson = "application/json"
+      self.isLoadingSend = true
+      
+      // Add all needed arguments to to create the post request. Print out the response from the API for success/fail
+      createHTTPRequest(httpMethod: "POST", url: url, accessToken: self.ekirjastoToken, jsonRequestBody: jsonData, contentType: appJson) { result in
+        switch result {
+        case .success(let response):
+          if let responseString = String(data: response, encoding: .utf8) {
+            print("response: \(responseString)")
+            self.isLoadingSend = false
+            self.showSuccess = true
+            self.alertMessage = tsx.thanks
+          } else {
+            let conversionError = NSError(domain: "ConversionErrorDomain", code: 1001, userInfo: [NSLocalizedDescriptionKey: "Failed to convert data to string"])
+            print("error: \(conversionError)")
+          }
+        case .failure(let error):
+          self.isLoadingSend = false
+          print("fail: \(error)")
+        }
+      }
+    }
+  }
+  
+  
+  /// Validates a given string for email validity.
+  /// - Parameter inputEmail: String: A string to be checked
+  /// - Returns: Boolean
   func validate(_ inputEmail: String) -> Bool {
     //TODO: validate email adress here
-    var email = inputEmail
+    let email = inputEmail
     print("Validating email given: " + email)
     let emailRegEx = "[A-Z0-9a-z._%+-]+@[A-Za-z0-9.-]+\\.[A-Za-z]{2,64}"
     let emailPred = NSPredicate(format:"SELF MATCHES %@", emailRegEx)

--- a/Palace/Settings/NewSettings/DependentsView.swift
+++ b/Palace/Settings/NewSettings/DependentsView.swift
@@ -7,147 +7,175 @@
 
 import SwiftUI
 
+/**
+ A model representing a dependent.
+ 
+ The `Dependent` struct conforms to `Codable`, `Identifiable`, and `Hashable` protocols. It represents a dependent with an ID, first name, and last name. The struct provides custom encoding and decoding to map JSON keys to its properties.
+ 
+ - Properties:
+ - id: A unique identifier for the dependent.
+ - firstName: The first name of the dependent.
+ - lastName: The last name of the dependent.
+ */
 struct Dependent: Codable, Identifiable, Hashable {
-    let id: String
-    let firstName: String
-    let lastName: String
-
+  let id: String
+  let firstName: String
+  let lastName: String
+  
   private enum CodingKeys: String, CodingKey {
-      case govId
-      case firstName
-      case lastName
+    case govId
+    case firstName
+    case lastName
   }
-
+  
   init(from decoder: Decoder) throws {
-      let container = try decoder.container(keyedBy: CodingKeys.self)
-      id = try container.decode(String.self, forKey: .govId)
-      firstName = try container.decode(String.self, forKey: .firstName)
-      lastName = try container.decode(String.self, forKey: .lastName)
+    let container = try decoder.container(keyedBy: CodingKeys.self)
+    id = try container.decode(String.self, forKey: .govId) // The API returns govId but we decode it to "id"
+    firstName = try container.decode(String.self, forKey: .firstName)
+    lastName = try container.decode(String.self, forKey: .lastName)
   }
   
   func encode(to encoder: Encoder) throws {
-      var container = encoder.container(keyedBy: CodingKeys.self)
-      try container.encode(id, forKey: .govId)
-      try container.encode(firstName, forKey: .firstName)
-      try container.encode(lastName, forKey: .lastName)
+    var container = encoder.container(keyedBy: CodingKeys.self)
+    try container.encode(id, forKey: .govId) // The API expects govId so we encode it back to "id"
+    try container.encode(firstName, forKey: .firstName)
+    try container.encode(lastName, forKey: .lastName)
   }
 }
 
+/**
+ A model representing a response containing a list of dependents.
+ 
+ The `LoikkaResponse` struct conforms to the `Codable` protocol and represents the response structure from an API call that returns a list of dependents.
+ 
+ - Properties:
+ - items: An array of `Dependent` objects.
+ */
 struct LoikkaResponse: Codable {
-    let items: [Dependent]
+  let items: [Dependent]
 }
 
 
+// The main view
 struct DependentsView: View {
   typealias tsx = Strings.Settings
   typealias tsxgeneric = Strings.Generic
   @State private var inputEmail: String = ""
-  @State private var isEmailValid: Bool = false
   @State private var ekirjastoToken: String = ""
-  @State var authDoc : OPDS2AuthenticationDocument? = nil
+  @State var authDoc : OPDS2AuthenticationDocument?
   @State private var fetchedDependents: [Dependent] = []
   @State private var showPicker: Bool = false
-  @State private var delegateToken = TPPUserAccount.sharedAccount().authToken!
   @State private var id = ""
   @State private var alertMessage = ""
   @State private var showAlert = false
   @State private var showSuccess = false
   @State private var isLoading: Bool = false
   @State private var isLoadingSend: Bool = false
-
+  
   
   var body: some View {
+    
     List{
-      Section {
+      if authDoc != nil {
         
-      } header: {
-        HStack{
-          Text(tsx.dependents)
-          Spacer()
-            .aspectRatio(contentMode: .fit)
-            .frame(width: 200)
-        }
-      }
-      
-      Section {
-        VStack {
-          // This is where it starts, the user taps the button to get their children/dependents
-          Button{
-            isLoading = true
-            getDependents()
-          } label: {
-            HStack{
-              Text(tsx.getDependents)
-              Spacer()
-              Image("ArrowRight")
-                .padding(.leading, 10)
-                .foregroundColor(Color(uiColor: .lightGray))
-            }
-          }
-          if isLoading {
-            ProgressView()
-          }
+        Section {
           
-          Section {
-            VStack {
-              // Once the request to Loikka has been made, this section becomes visible
-              if showPicker {
-                
-                if fetchedDependents.isEmpty {
-                  Text(tsx.noDependents).tag(tsx.noDependents)
-                  
-                } else {
-                  Picker(tsx.select, selection: $id) {
-                    Text(tsx.selectADependent).tag(tsx.selectADependent)
-                    // Show the name of the fetched dependents and store their id
-                    ForEach(fetchedDependents, id: \.id) { dependent in
-                      Text(dependent.firstName).tag(dependent.id)
-                    }
-                  }
-                  
-                }
+        } header: {
+          HStack{
+            Text(tsx.dependents)
+            Spacer()
+              .aspectRatio(contentMode: .fit)
+              .frame(width: 200)
+          }
+        }
+        
+        Section {
+          VStack {
+            // This is where it starts, the user taps the button to get their children/dependents
+            Button{
+              isLoading = true
+              getDependents()
+            } label: {
+              HStack{
+                Text(tsx.getDependents)
+                Spacer()
+                Image("ArrowRight")
+                  .padding(.leading, 10)
+                  .foregroundColor(Color(uiColor: .lightGray))
               }
             }
-            .alert(isPresented: $showAlert) {
-              Alert(title: Text(tsxgeneric.error), message: Text(alertMessage), dismissButton: .default(Text(tsxgeneric.ok)))
+            if isLoading {
+              ProgressView()
+            }
+            
+            Section {
+              VStack {
+                // Once the request to Loikka has been made, this section becomes visible
+                if showPicker {
+                  
+                  // If the user doesn't have any dependents, inform them
+                  if fetchedDependents.isEmpty {
+                    Text(tsx.noDependents).tag(tsx.noDependents)
+                      .padding()
+                    
+                    // If a list of dependents is returned, show them in a picker
+                  } else {
+                    Picker(tsx.select, selection: $id) {
+                      Text(tsx.selectADependent).tag(tsx.selectADependent)
+                      // Show the name of the fetched dependents and store their id
+                      ForEach(fetchedDependents, id: \.id) { dependent in
+                        Text(dependent.firstName).tag(dependent.id)
+                      }
+                    }
+                    
+                  }
+                }
+              }
+              // Show an alert if the requests were unsuccessful
+              .alert(isPresented: $showAlert) {
+                Alert(title: Text(tsxgeneric.error), message: Text(alertMessage), dismissButton: .default(Text(tsxgeneric.ok)))
+              }
             }
           }
         }
-      }
-      
+        
         // If the user has selected a dependent, we show them an email text field
         if id != "" {
-            VStack {
-              Text(tsx.guideText)
-                .foregroundStyle(Color(uiColor: .lightGray))
-                .font(.subheadline)
-                .padding()
-                .frame(maxWidth: .infinity, alignment: .leading)
-              TextField(tsx.enterEmail, text: $inputEmail)
-                .padding()
-                .border(Color(uiColor: .lightGray), width: 1)
-                .cornerRadius(3)
-
-              Button {
-                sendInviteToDependent(dependentId: id)
-              } label: {
-                HStack {
-                  Text(tsx.sendButton)
-                  Image("ArrowRight")
-                    .padding(.leading, 10)
-                    .foregroundColor(Color(uiColor: .lightGray))
-                }
-                .padding(10)
+          VStack {
+            Text(tsx.guideText)
+              .foregroundStyle(Color(uiColor: .lightGray))
+              .font(.subheadline)
+              .padding()
+              .frame(maxWidth: .infinity, alignment: .leading)
+            TextField(tsx.enterEmail, text: $inputEmail)
+              .padding()
+              .border(Color(uiColor: .lightGray), width: 1)
+              .cornerRadius(3)
+            Spacer()
+            
+            // Tapping this button will send out the invite
+            Button {
+              sendInviteToDependent(dependentId: id)
+            } label: {
+              HStack {
+                Text(tsx.sendButton)
+                Image("ArrowRight")
+                  .padding(.leading, 10)
+                  .foregroundColor(Color(uiColor: .lightGray))
               }
-
+              .padding(10)
             }
-            .alert(isPresented: $showAlert) {
-              Alert(title: Text(tsxgeneric.error), message: Text(alertMessage), dismissButton: .default(Text(tsxgeneric.ok)))
-            }
-            .alert(isPresented: $showSuccess) {
-              Alert(title: Text(tsx.successButton), message: Text(alertMessage), dismissButton: .default(Text(tsxgeneric.ok)))
-            }
+            
+          }
+          // Show an error message if any problems occur, otherwise show a success message
+          .alert(isPresented: $showAlert) {
+            Alert(title: Text(tsxgeneric.error), message: Text(alertMessage), dismissButton: .default(Text(tsxgeneric.ok)))
+          }
+          .alert(isPresented: $showSuccess) {
+            Alert(title: Text(tsx.successButton), message: Text(alertMessage), dismissButton: .default(Text(tsxgeneric.ok)))
+          }
           
+          // It's nice to show the user some progress until the request has been executed
           if isLoadingSend {
             VStack {
               ProgressView()
@@ -156,15 +184,31 @@ struct DependentsView: View {
           }
         }
       }
+    }
+    .onAppear {
+      fetchAuthDoc { doc in
+        self.authDoc = doc
+      }
+    }
   }
   
 
-  
+  /**
+   Fetches the authentication document for the current account or the first available account.
+   
+   This function attempts to retrieve the `OPDS2AuthenticationDocument` for the current account managed by `AccountsManager`. If the current account does not have an authentication document loaded, it will attempt to load it asynchronously. If there is no current account, it will try to load the authentication document for the first available account. The result is returned via a completion handler.
+   
+   - Parameter completion: A closure that is called with the fetched `OPDS2AuthenticationDocument` or `nil` if no document could be fetched. The closure takes a single parameter:
+   - `doc`: An optional `OPDS2AuthenticationDocument` representing the fetched authentication document.
+   - Note: The completion handler is called on the main thread.
+   */
   func fetchAuthDoc(completion: @escaping (_ doc: (OPDS2AuthenticationDocument?))->Void){
     if let currentAccount = AccountsManager.shared.currentAccount {
+      // If the current account already has an authentication document, return it
       if let doc = currentAccount.authenticationDocument {
         completion(doc)
       }else{
+        // Otherwise, load the authentication document asynchronously
         currentAccount.loadAuthenticationDocument(completion: { Bool in
           DispatchQueue.main.async {
             completion(currentAccount.authenticationDocument)
@@ -172,6 +216,7 @@ struct DependentsView: View {
         })
       }
     }else if let account = AccountsManager.shared.accounts().first {
+      // Load the authentication document for the first available account asynchronously
       account.loadAuthenticationDocument(completion: { Bool in
         DispatchQueue.main.async {
           completion(account.authenticationDocument!)
@@ -182,196 +227,163 @@ struct DependentsView: View {
     }
   }
   
-  enum HTTPError: Error {
-      case serverError
-      case unknown
+  /**
+   Fetches the link for a given relation (rel) from the authentication object.
+   - Parameters:
+   - rel: The relation (rel) to search for in the links.
+   - Returns: The found link as a string, or `nil` if no matching link is found.
+   */
+  func getLink(forRel rel: String) -> String? {
     
-    func errorMessage() -> String {
-        switch self {
-        case .serverError:
-            return tsx.errorFromServer
-        case .unknown:
-          return tsx.errorInCreation
-        }
-    }
-  }
-
-  
-  /// A general http request function that returns the response when the request has been successful and handles different unsuccessful responses.
-  /// - Parameters:
-  ///   - httpMethod: String: Http method to be used, e.g. "GET"
-  ///   - url: String: The URL of the request
-  ///   - accessToken: String: Bearer token to be used for the request
-  ///   - jsonRequestBody: Optional JSON data: For POST requests, a JSON request body
-  ///   - completion: Returns the response
-  func createHTTPRequest(httpMethod: String, url: String, accessToken: String, jsonRequestBody: Data? = nil, contentType: String? = nil, completion: @escaping (Result<Data, HTTPError>) -> Void) {
-      // Set up the http request
-      let url = URL(string: url)!
-      var request = URLRequest(url: url)
-      request.httpMethod = httpMethod
-      request.setValue("Bearer \(accessToken)", forHTTPHeaderField: "Authorization")
-      
-      if let contentTypeString = contentType {
-        request.setValue(contentTypeString, forHTTPHeaderField: "Content-Type")
-    }
-      if let requestBody = jsonRequestBody {
-        request.httpBody = requestBody
-    }
-      // Execute the request and handle errors based on the response status code.
-      let task = URLSession.shared.dataTask(with: request) { data, response, error in
-        print("HTTP request to: \(request)")
-          if let error = error {
-            self.showAlert = true
-            self.alertMessage = HTTPError.unknown.errorMessage()
-              print("Request error: \(error)")
-            completion(.failure(.unknown))
-              return
-          }
-          
-          guard let httpResponse = response as? HTTPURLResponse else {
-            self.showAlert = true
-            self.alertMessage = HTTPError.unknown.errorMessage()
-            print("alerts: \(self.alertMessage), \(self.showAlert)")
-            completion(.failure(.unknown))
-            return
-          }
-          
-          switch httpResponse.statusCode {
-          case 200...299:
-              if let data = data {
-                // Successful response returns the data
-                  completion(.success(data))
-              } else {
-                // If data is nil, return an appropriate error
-                self.showAlert = true
-                self.alertMessage = HTTPError.unknown.errorMessage()
-                print("alerts: \(self.alertMessage), \(self.showAlert)")
-                completion(.failure(.unknown))
-              }
-          default:
-            self.showAlert = true
-            self.alertMessage = HTTPError.serverError.errorMessage()
-            print("alerts: \(self.alertMessage), \(self.showAlert)")
-            print("HTTP status code: \(httpResponse.statusCode)")
-            // Use a default error for non-2xx status codes
-            completion(.failure(.serverError))
-          }
-      }
-      task.resume()
-  }
-
-  
-/// Function that fetches a user's e-kirjasto token from e-kirjasto circulation backend. A successful request returns the token.
-/// - Parameters:
-///   - accessToken: String: A delegate token that allows making requests to e-kirjasto backend.
-  func getEkirjastoToken(accessToken: String, completion: @escaping (Result<String, Error>) -> Void) {
+    // Find the authentication object of ekirjasto type
+    let authentication = self.authDoc?.authentication?.first(where: { $0.type == "http://e-kirjasto.fi/authtype/ekirjasto" })
     
-    let delegateToken = self.delegateToken
-    print("Start circulation request with: \(delegateToken)")
-    let url = "https://lib-dev.e-kirjasto.fi/ekirjasto/ekirjasto_token?provider=E-kirjasto+provider+for+circulation+manager"
+    // Find the link with the specified relation (rel)
+    let link = authentication?.links?.first(where: { $0.rel == rel })?.href
     
-      createHTTPRequest(httpMethod: "GET", url: url, accessToken: delegateToken) { result in
-          switch result {
-          case .success(let data):
-              do {
-                if let jsonResponse = try JSONSerialization.jsonObject(with: data, options: []) as? [String: Any],
-                   let token = jsonResponse["token"] as? String {
-                    print("We got this token from circulation: \(token)")
-                    completion(.success(token))
-                } else {
-                  let parsingError = NSError(domain: "", code: 0, userInfo: [NSLocalizedDescriptionKey: "JSON response does not contain the expected data"])
-                  completion(.failure(parsingError))
-                }
-              } catch {
-                  print("Decoding error: \(error)")
-                completion(.failure(error))
-              }
-          case .failure(let error):
-              completion(.failure(error))
-          }
-      }
+    return link
   }
   
-  /// Function that makes a request to e-kirjasto authentication service using a valid e-kirjasto token and the user's (patron's) permanent id in e-kirjasto services. A successful request returns a list of dependents.
-  /// - Parameters:
-  ///   - accessToken: String: A valid e-kirjasto token
-  ///   - patronPermanantId:  String: The user's permanent id in the e-kirjasto services.
-  ///   - completion: List: A list of decoded Depenedent objects is returned.
-  func getDependentsRequest(accessToken: String, patronPermanantId: String, completion: @escaping (Result<[Dependent], Error>) -> Void) {
-   
-    print("Start Dependents request: \(accessToken)")
-    let url = "\("https://e-kirjasto.loikka.dev/v1/identities/")\(patronPermanantId)\("/relations")"
-  
-    createHTTPRequest(httpMethod: "GET", url: url, accessToken: accessToken) { result in
-            switch result {
-            case .success(let response):
-                do {
-                  // Decode the json reponse into Depenedent objects and return them as a list
-                    let decodedData = try JSONDecoder().decode(LoikkaResponse.self, from: response)
-                    print("Dependents: \(decodedData.items)")
-                    completion(.success(decodedData.items))
-                } catch {
-                  let parsingError = NSError(domain: "", code: 0, userInfo: [NSLocalizedDescriptionKey: "JSON response does not contain the expected data"])
-                  completion(.failure(parsingError))
-                }
-      
-            case .failure(let error):
-              completion(.failure(error))
-            }
-    }
-  }
-  
-  
-  /// Function that takes the signed in user's stored delegate token (=circulation token) to make a request to circulation backend to fetch the latest e-kirjasto token. Using the fetched e-kirjasto token, a new request is made to the authentication servive to get a list of the user's dependents. If a user does not have any dependents, an empty list is returned.
+  /**
+   Fetches the dependents for the current user.
+   This function first uses the stored delegate token to get a valid e-kirjasto token. Once the e-kirjasto token is obtained, it uses it to fetch the user's dependents. The result is stored in properties for later use and updates the UI accordingly.
+   */
   func getDependents(){
     print("Getting dependents...")
-    let patronPermanentId = TPPUserAccount.sharedAccount().patronPermantId!
-    print("Permanent id: " + patronPermanentId)
-    print("E-kirjasto token: \(self.delegateToken)")
     
-    // First use the stored delegate token to get a valid e-kirjasto token
-    getEkirjastoToken(accessToken: self.delegateToken) { circulationResult in
-        switch circulationResult {
-        case .success(let ekirjastoToken):
-          // store the e-kirjasto token to properties for later use.
-          self.ekirjastoToken = ekirjastoToken
-            
-            // Get the user's dependents now that we have an e-kirjasto token
-          getDependentsRequest(accessToken: ekirjastoToken, patronPermanantId: patronPermanentId) { dependentsResult in
-                  switch dependentsResult {
-                    case .success(let dependents):
-                      self.showPicker = true
-                      self.fetchedDependents = dependents
-                    if let firstDependent = fetchedDependents.first {
-                        print(firstDependent.firstName)
-                      // Store the first dependent's id to be used in the view's picker
-                      self.id = firstDependent.id
-                      self.isLoading = false
-                    } else {
-                        // fetchedDependents on tyhjä
-                        print("No dependents available")
-                    }
-                    case .failure(let error):
-                      print("error: \(error)")
-                  }
+    // Get the permanent ID of the signed in user
+    let patronPermanentId = TPPUserAccount.sharedAccount().patronPermantId!
+    
+    // First get a valid e-kirjasto token
+    getEkirjastoToken() { result in
+      switch result {
+      case .success(let ekirjastoToken):
+        // Store the e-kirjasto token to properties for later use.
+        self.ekirjastoToken = ekirjastoToken
+        
+        // Get the user's dependents now that we have an e-kirjasto token
+        getDependentsRequest(accessToken: ekirjastoToken, patronPermanantId: patronPermanentId) { dependentsResult in
+          switch dependentsResult {
+          case .success(let dependents):
+            // Update UI properties with the fetched dependents
+            self.showPicker = true
+            self.fetchedDependents = dependents
+            if let firstDependent = fetchedDependents.first {
+              print(firstDependent.firstName)
+              // Store the first dependent's id to be used in the view's picker
+              self.id = firstDependent.id
+              self.isLoading = false
+            } else {
+              // fetchedDependents on tyhjä
+              print("No dependents available")
+              self.isLoading = false
             }
-        case .failure(let error):
-          print("error: \(error)")
+          case .failure(let error):
+            // Handle error in fetching dependents
+            self.isLoading = false
+            print("error: \(error)")
+          }
         }
+      case .failure(let error):
+        // Handle error in getting the e-kirjasto token
+        self.isLoading = false
+        print("error: \(error)")
+      }
     }
   }
   
-  /// Function that encodes the selected dependent's information to a JSON request body and makes a post request to the authentication service invite endpoint.
-  /// - Parameter dependentId: String: Selected dependent's id
+  /**
+   Function that fetches a user's e-kirjasto token from e-kirjasto circulation backend.
+   - Parameters:
+   - accessToken: The access token to use for authentication in the HTTP request.
+   - completion: A closure that is called with the result of the token fetch request. The closure takes a single parameter:
+   - result: A `Result<String, Error>` containing the token on success or an `Error` on failure.
+   */
+  func getEkirjastoToken(completion: @escaping (Result<String, Error>) -> Void) {
+    print("Starting getEkirjastoToken...")
+    
+    // Get the stored delegate token of the user
+    let delegateToken = TPPUserAccount.sharedAccount().authToken!
+    let link = getLink(forRel: "ekirjasto_token")
+    
+    // Create and execute the HTTP request to fetch the token
+    createHTTPRequest(httpMethod: "GET", url: link!, accessToken: delegateToken) { result in
+      switch result {
+      case .success(let data):
+        do {
+          // Parse the JSON response to extract the token
+          if let jsonResponse = try JSONSerialization.jsonObject(with: data, options: []) as? [String: Any],
+             let token = jsonResponse["token"] as? String {
+            print("We got this token from circulation: \(token)")
+            completion(.success(token))
+          } else {
+            // Handle the case where the JSON response does not contain the expected data
+            let parsingError = NSError(domain: "", code: 0, userInfo: [NSLocalizedDescriptionKey: "JSON response does not contain the expected data"])
+            completion(.failure(parsingError))
+          }
+        } catch {
+          // Handle JSON parsing errors
+          print("Decoding error: \(error)")
+          completion(.failure(error))
+        }
+      case .failure(let error):
+        // Handle HTTP request errors
+        completion(.failure(error))
+      }
+    }
+  }
+  
+  /**
+   Fetches the list of dependents for a given patron using their permanent ID. The data is fetched from the authentication service API.
+   - Parameters:
+   - accessToken: The access token to use for authentication in the HTTP request.
+   - patronPermanantId: The permanent ID of the patron for whom to fetch dependents.
+   - completion: A closure that is called with the result of the dependents fetch request. The closure takes a single parameter:
+   - result: A `Result<[Dependent], Error>` containing the list of dependents on success or an `Error` on failure.
+   */
+  func getDependentsRequest(accessToken: String, patronPermanantId: String, completion: @escaping (Result<[Dependent], Error>) -> Void) {
+    print("Start Dependents request: \(accessToken)")
+    
+    // Get the relations link and replace "patron" with the provided patron permanent ID
+    let relationsString = getLink(forRel: "relations")
+    let patronUrl = relationsString?.replacingOccurrences(of: "patron", with: patronPermanantId)
+    
+    createHTTPRequest(httpMethod: "GET", url: patronUrl!, accessToken: accessToken) { result in
+      switch result {
+      case .success(let response):
+        do {
+          // Decode the json reponse into Depenedent objects and return them as a list
+          let decodedData = try JSONDecoder().decode(LoikkaResponse.self, from: response)
+          print("Dependents: \(decodedData.items)")
+          completion(.success(decodedData.items))
+        } catch {
+          let parsingError = NSError(domain: "", code: 0, userInfo: [NSLocalizedDescriptionKey: "JSON response does not contain the expected data"])
+          completion(.failure(parsingError))
+        }
+      case .failure(let error):
+        completion(.failure(error))
+      }
+    }
+  }
+  
+  
+  /**
+   Function that encodes the selected dependent's information to a JSON request body and makes a post request to the authentication service invite endpoint.
+   - Parameters:
+   - dependentId: The user's selected id of the dependent
+   */
   func sendInviteToDependent(dependentId: String) {
     print("Start Dependent invite function")
     
-    // Check here that the typed in email is valid
+    // Check here that the typed in email is valid and proceed if it's valid. Otherwise, show an alert.
     let emailValid = validate(self.inputEmail)
     if !emailValid {
       self.alertMessage = tsx.incorrectEmail
       self.showAlert = true
     } else {
+      
+      // Get the locale of the current user. We assume the dependent most likely will prefer the same language for the invite.
+      let langCode = Locale.current.languageCode
       
       var jsonData: Data?
       // Find the Dependent with the matching id (user selected it in the picker)
@@ -384,10 +396,10 @@ struct DependentsView: View {
           "lastName": dependentObject.lastName,
           "govId": dependentObject.id,
           "email": self.inputEmail,
-          "locale": "fi",
+          "locale": langCode!,
           "role": "customer"
         ].compactMapValues { $0 }
-        
+        print("data here: \(dictionary)")
         // Encode the dictionary to JSON
         do {
           let encodedData = try JSONEncoder().encode(dictionary)
@@ -395,28 +407,33 @@ struct DependentsView: View {
         } catch {
           print("Error encoding dictionary to JSON: \(error)")
         }
+        // Shouldn't happen, but just in case, print the id if there's no matching Dependent
       } else {
         print("No matching dependent: \(dependentId)!")
       }
       
-      let url = "https://e-kirjasto.loikka.dev/v1/identities/invite"
-      let appJson = "application/json"
+      let inviteUrl = getLink(forRel: "invite")
+      
+      // Once the request is made, the user should be shown progress
       self.isLoadingSend = true
       
       // Add all needed arguments to to create the post request. Print out the response from the API for success/fail
-      createHTTPRequest(httpMethod: "POST", url: url, accessToken: self.ekirjastoToken, jsonRequestBody: jsonData, contentType: appJson) { result in
+      createHTTPRequest(httpMethod: "POST", url: inviteUrl!, accessToken: self.ekirjastoToken, jsonRequestBody: jsonData, contentType: "application/json") { result in
         switch result {
+          // When the request is made successfully, show the user a message, print the response and update UI properties
         case .success(let response):
           if let responseString = String(data: response, encoding: .utf8) {
             print("response: \(responseString)")
             self.isLoadingSend = false
             self.showSuccess = true
             self.alertMessage = tsx.thanks
+            self.inputEmail = ""
           } else {
             let conversionError = NSError(domain: "ConversionErrorDomain", code: 1001, userInfo: [NSLocalizedDescriptionKey: "Failed to convert data to string"])
             print("error: \(conversionError)")
           }
         case .failure(let error):
+          // Handle reqeust errors
           self.isLoadingSend = false
           print("fail: \(error)")
         }
@@ -424,19 +441,112 @@ struct DependentsView: View {
     }
   }
   
+
+  // HTTP errors mapped to specific messages
+  enum HTTPError: Error {
+    case serverError
+    case unknown
+    
+    func errorMessage() -> String {
+      switch self {
+      case .serverError:
+        return tsx.errorFromServer
+      case .unknown:
+        return tsx.errorInCreation
+      }
+    }
+  }
   
-  /// Validates a given string for email validity.
-  /// - Parameter inputEmail: String: A string to be checked
-  /// - Returns: Boolean
+  /**
+   Creates and executes an HTTP request.
+   
+   This function sets up an HTTP request with the specified method, URL, access token, and optional request body and content type. It then executes the request and handles the response, returning the result via a completion handler.
+   
+   - Parameters:
+   - httpMethod: The HTTP method to use for the request (e.g., "GET", "POST").
+   - url: The URL string for the request.
+   - accessToken: The access token to include in the `Authorization` header.
+   - jsonRequestBody: Optional. The JSON request body to include in the request.
+   - contentType: Optional. The content type to include in the `Content-Type` header.
+   - completion: A closure that is called with the result of the request. The closure takes a single parameter:
+   - result: A `Result<Data, HTTPError>` containing the response data on success or an `HTTPError` on failure.
+   */
+  func createHTTPRequest(httpMethod: String, url: String, accessToken: String, jsonRequestBody: Data? = nil, contentType: String? = nil, completion: @escaping (Result<Data, HTTPError>) -> Void) {
+    print("Starting createHTTPRequest...")
+    
+    // Set up the http request with given arguments
+    let url = URL(string: url)!
+    var request = URLRequest(url: url)
+    request.httpMethod = httpMethod
+    request.setValue("Bearer \(accessToken)", forHTTPHeaderField: "Authorization")
+    
+    // Set the Content-Type header if provided
+    if let contentTypeString = contentType {
+      request.setValue(contentTypeString, forHTTPHeaderField: "Content-Type")
+    }
+    
+    // Set the request body if provided
+    if let requestBody = jsonRequestBody {
+      request.httpBody = requestBody
+    }
+    
+    // Execute the request and handle errors based on the response status code.
+    let task = URLSession.shared.dataTask(with: request) { data, response, error in
+      print("HTTP request to: \(request)")
+      
+      // Handle any request error
+      if let error = error {
+        self.showAlert = true
+        self.alertMessage = HTTPError.unknown.errorMessage()
+        print("Request error: \(error)")
+        completion(.failure(.unknown))
+        return
+      }
+      
+      // Ensure the response is an HTTP response. Show an alert if not.
+      guard let httpResponse = response as? HTTPURLResponse else {
+        self.showAlert = true
+        self.alertMessage = HTTPError.unknown.errorMessage()
+        completion(.failure(.unknown))
+        return
+      }
+      
+      // Handle the HTTP status codes
+      switch httpResponse.statusCode {
+      case 200...299:
+        if let data = data {
+          // Successful response returns the data
+          completion(.success(data))
+        } else {
+          // If data is nil, return an appropriate error and show an alert
+          self.showAlert = true
+          self.alertMessage = HTTPError.unknown.errorMessage()
+          completion(.failure(.unknown))
+        }
+      default:
+        // Handle non-2xx status codes and show an alert
+        self.showAlert = true
+        self.alertMessage = HTTPError.serverError.errorMessage()
+        print("HTTP status code: \(httpResponse.statusCode)")
+        // Use a default error for non-2xx status codes
+        completion(.failure(.serverError))
+      }
+    }
+    task.resume()
+  }
+  
+  /**
+   Validates a given string for email validity.
+   - Parameter inputEmail: A string to be checked
+   - Returns: Boolean
+   */
   func validate(_ inputEmail: String) -> Bool {
-    //TODO: validate email adress here
     let email = inputEmail
-    print("Validating email given: " + email)
     let emailRegEx = "[A-Z0-9a-z._%+-]+@[A-Za-z0-9.-]+\\.[A-Za-z]{2,64}"
     let emailPred = NSPredicate(format:"SELF MATCHES %@", emailRegEx)
     return emailPred.evaluate(with: email)  }
 }
 
 #Preview {
-    DependentsView()
+  DependentsView()
 }

--- a/Palace/Settings/NewSettings/DependentsView.swift
+++ b/Palace/Settings/NewSettings/DependentsView.swift
@@ -37,7 +37,7 @@ struct Dependent: Codable, Identifiable, Hashable {
   
   func encode(to encoder: Encoder) throws {
     var container = encoder.container(keyedBy: CodingKeys.self)
-    try container.encode(id, forKey: .govId) // The API expects govId so we encode it back to "id"
+    try container.encode(id, forKey: .govId) // The API expects govId so we encode it back to that
     try container.encode(firstName, forKey: .firstName)
     try container.encode(lastName, forKey: .lastName)
   }
@@ -151,6 +151,9 @@ struct DependentsView: View {
               .padding()
               .border(Color(uiColor: .lightGray), width: 1)
               .cornerRadius(3)
+              .disableAutocorrection(true)
+              .autocapitalization(.none)
+              .keyboardType(.emailAddress)
             Spacer()
             
             // Tapping this button will send out the invite

--- a/Palace/Settings/NewSettings/DependentsView.swift
+++ b/Palace/Settings/NewSettings/DependentsView.swift
@@ -1,0 +1,257 @@
+//
+//  DependentsView.swift
+//  E-kirjasto
+//
+//  Created by Kupe, Joona on 25.7.2024.
+//
+
+import SwiftUI
+
+struct DependentsView: View {
+  typealias tsx = Strings.Settings
+  @State private var username: String = ""
+  var dependents = ["Select a Dependent", "No Dependents Found"]
+  @State private var selectedDependents = "Select a Dependent"
+  @State private var circulationToken: String = ""
+  @State var authDoc : OPDS2AuthenticationDocument? = nil
+  @State private var LoikkaDependents: [String] = []
+
+  var body: some View {
+    List{
+      Section {
+        
+      } header: {
+        HStack{
+          Text(tsx.dependents)
+          Spacer()
+            .aspectRatio(contentMode: .fit)
+            .frame(width: 200)
+        }
+      }
+      Button{
+        var res = getDependents()
+      } label: {
+        HStack{
+          Text(tsx.getDependents)
+          Spacer()
+          Image("ArrowRight")
+            .padding(.leading, 10)
+            .foregroundColor(Color(uiColor: .lightGray))
+        }
+      }
+      //TODO: picker here
+      VStack{
+        Spacer()
+        Picker(tsx.select, selection: $selectedDependents){
+          ForEach(LoikkaDependents, id: \.self){ dependent in
+            Text(dependent)
+          }
+        }
+      }
+      Text(tsx.selected + "\n\n\n\(selectedDependents)")
+      TextField(
+        tsx.enterEmail,
+        text: $username
+        
+      )
+      Button{
+        let valid = validate(username)
+        print("Result of validating " + username + "is: ")
+        if valid {
+          //stuff
+          print("Yes, valid")
+        }
+        else{
+          //some other stuff, genious right?
+          print("No, not valid")
+          username = tsx.incorrectEmail
+        }
+      } label: {
+        HStack{
+          Text(tsx.sendButton)
+          Spacer()
+          Image("ArrowRight")
+            .padding(.leading, 10)
+            .foregroundColor(Color(uiColor: .lightGray))
+        }
+      }
+    }
+  }
+  
+  func fetchAuthDoc(completion: @escaping (_ doc: (OPDS2AuthenticationDocument?))->Void){
+    if let currentAccount = AccountsManager.shared.currentAccount {
+      if let doc = currentAccount.authenticationDocument {
+        completion(doc)
+      }else{
+        currentAccount.loadAuthenticationDocument(completion: { Bool in
+          DispatchQueue.main.async {
+            completion(currentAccount.authenticationDocument)
+          }
+        })
+      }
+    }else if let account = AccountsManager.shared.accounts().first {
+      account.loadAuthenticationDocument(completion: { Bool in
+        DispatchQueue.main.async {
+          completion(account.authenticationDocument!)
+        }
+      })
+    }else{
+      completion(nil)
+    }
+  }
+  
+  func makeGetRequestWithAccessToken(url: String, accessToken: String, completion: @escaping (Result<String, Error>) -> Void) {
+    let url = URL(string: url)!
+    var request = URLRequest(url: url)
+    request.httpMethod = "GET"
+    request.setValue("Bearer \(accessToken)", forHTTPHeaderField: "Authorization")
+    
+    let task = URLSession.shared.dataTask(with: request) { data, response, error in
+        if let error = error {
+            print("Request error: ", error)
+            completion(.failure(error))
+            return
+        }
+        
+        guard let httpResponse = response as? HTTPURLResponse else {
+            let responseError = NSError(domain: "HTTP", code: 0, userInfo: [NSLocalizedDescriptionKey: "Invalid HTTP response"])
+            completion(.failure(responseError))
+            return
+        }
+      print("status code: \(httpResponse.statusCode)")
+        if httpResponse.statusCode == 200 {
+            guard let data = data else {
+                let dataError = NSError(domain: "Data", code: 0, userInfo: [NSLocalizedDescriptionKey: "Invalid data"])
+                completion(.failure(dataError))
+                return
+            }
+            
+            if let responseString = String(data: data, encoding: .utf8) {
+                DispatchQueue.main.async {
+                    completion(.success(responseString))
+                }
+            } else {
+                let dataParsingError = NSError(domain: "Data", code: 0, userInfo: [NSLocalizedDescriptionKey: "Data parsing error"])
+                completion(.failure(dataParsingError))
+            }
+        } else {
+            let statusCodeError = NSError(domain: "HTTP", code: httpResponse.statusCode, userInfo: [NSLocalizedDescriptionKey: "Invalid status code"])
+            completion(.failure(statusCodeError))
+        }
+    }
+    task.resume()
+  }
+  
+  func getCirculationToken(accessToken: String, completion: @escaping (Result<String, Error>) -> Void) {
+    
+    print("Start circulation request: \(accessToken)")
+    let url = "https://lib-dev.e-kirjasto.fi/ekirjasto/ekirjasto_token?provider=E-kirjasto+provider+for+circulation+manager"
+
+    makeGetRequestWithAccessToken(url: url, accessToken: accessToken) { result in
+      switch result {
+      case .success(let response):
+        print("Circulation response: \(response)")
+        if let data = response.data(using: .utf8) {
+            do {
+                if let json = try JSONSerialization.jsonObject(with: data, options: []) as? [String: Any],
+                   let token = json["token"] as? String {
+                    completion(.success(token))
+                } else {
+                    let parsingError = NSError(domain: "JSON", code: 0, userInfo: [NSLocalizedDescriptionKey: "Invalid JSON format or missing 'token'"])
+                    completion(.failure(parsingError))
+                }
+            } catch {
+                completion(.failure(error))
+            }
+        } else {
+            let dataError = NSError(domain: "Data", code: 0, userInfo: [NSLocalizedDescriptionKey: "Failed to convert response string to data"])
+            completion(.failure(dataError))
+        }
+
+      case .failure(let error):
+        print("Circulation Error: \(error)")
+        completion(.failure(error))
+      }
+    }
+  }
+  
+  
+  func getDependentsRequest(accessToken: String, patronPermanantId: String, completion: @escaping (Result<[String], Error>) -> Void) {
+   
+    print("Start Dependents request: \(accessToken)")
+    let url = "\("https://e-kirjasto.loikka.dev/v1/identities/")\(patronPermanantId)\("/relations")"
+
+    makeGetRequestWithAccessToken(url: url, accessToken: accessToken) { result in
+      switch result {
+      case .success(let response):
+        print("Loikka response: \(response)")
+        if let data = response.data(using: .utf8) {
+            do {
+                if let json = try JSONSerialization.jsonObject(with: data, options: []) as? [String: Any],
+                   let items = json["items"] as? [[String: Any]] {
+                    let firstNames = items.compactMap { $0["firstName"] as? String }
+                    completion(.success(firstNames))
+                } else {
+                    let parsingError = NSError(domain: "JSON", code: 0, userInfo: [NSLocalizedDescriptionKey: "Invalid JSON format or missing 'items'"])
+                    completion(.failure(parsingError))
+                }
+            } catch {
+                completion(.failure(error))
+            }
+        } else {
+            let dataError = NSError(domain: "Data", code: 0, userInfo: [NSLocalizedDescriptionKey: "Failed to convert response string to data"])
+            completion(.failure(dataError))
+        }
+
+      case .failure(let error):
+        print("Dependents Error: \(error)")
+        completion(.failure(error))
+      }
+    }
+  }
+  
+
+  func getDependents(){
+    print("Getting dependents...")
+    let patronPermanentId = TPPUserAccount.sharedAccount().patronPermantId!
+    print("Permanent id: " + patronPermanentId)
+    let currentEkirjastoToken = TPPUserAccount.sharedAccount().authToken!
+    print("Ekirajsto token: \(currentEkirjastoToken)")
+    getCirculationToken(accessToken: currentEkirjastoToken) { circulationResult in
+        switch circulationResult {
+        case .success(let circulationToken):
+            getDependentsRequest(accessToken: circulationToken, patronPermanantId: patronPermanentId) { dependentsResult in
+                switch dependentsResult {
+                case .success(let dependents):
+                    print("Dependents: \(dependents)")
+                  self.LoikkaDependents = dependents
+                case .failure(let error):
+                  print("error: \(error)")
+                }
+            }
+        case .failure(let error):
+          print("error: \(error)")
+        }
+    }
+
+    //TODO: get method to fetch dependents from Loikka
+    //TODO: to put in a picker programmatically and
+    //TODO: to show user input for dependent email
+    
+    //TODO: fetch account id
+    
+    //finally return
+  }
+  
+  func validate(_ username: String) -> Bool {
+    //TODO: validate email adress here
+    var email = username
+    print("Validating email given: " + email)
+    let emailRegEx = "[A-Z0-9a-z._%+-]+@[A-Za-z0-9.-]+\\.[A-Za-z]{2,64}"
+    let emailPred = NSPredicate(format:"SELF MATCHES %@", emailRegEx)
+    return emailPred.evaluate(with: email)  }
+}
+
+#Preview {
+    DependentsView()
+}

--- a/Palace/Settings/NewSettings/TPPSettingsView.swift
+++ b/Palace/Settings/NewSettings/TPPSettingsView.swift
@@ -172,7 +172,7 @@ struct TPPSettingsView: View {
            }
          }
        }
-       
+    
      } message: {
        Text(self.logoutText)
      }
@@ -210,6 +210,12 @@ struct TPPSettingsView: View {
        }
 
      }
+     
+     NavigationLink(
+       destination:
+         DependentsView()){
+           Text(DisplayStrings.dependentsButton)
+         }
    }
   }
   

--- a/Palace/Utilities/Localization/Strings.swift
+++ b/Palace/Utilities/Localization/Strings.swift
@@ -123,6 +123,16 @@ struct Strings {
     static let loginFooterUserAgreementText = NSLocalizedString("By signing in, you agree the End User License Agreement", comment: "")
     static let faq = NSLocalizedString("FAQ", comment: "")
     
+    //dependents
+    static let dependentsButton = NSLocalizedString("Invite a Dependent", comment: "")
+    static let dependents = NSLocalizedString("Dependents", comment: "")
+    static let getDependents = NSLocalizedString("Get Dependents", comment: "")
+    static let select = NSLocalizedString("Select", comment: "")
+    static let selected = NSLocalizedString("Selected Dependent is: ", comment: "")
+    static let enterEmail = NSLocalizedString("Enter email of a Dependent: ", comment: "")
+    static let incorrectEmail = NSLocalizedString("Incorrect email", comment: "")
+    static let sendButton = NSLocalizedString("Send invite", comment: "")
+    
   }
   
   struct Preferences {

--- a/Palace/Utilities/Localization/Strings.swift
+++ b/Palace/Utilities/Localization/Strings.swift
@@ -136,7 +136,7 @@ struct Strings {
     static let noDependents = NSLocalizedString("No dependents or children found.", comment: "")
     static let errorFromServer = NSLocalizedString("Something went wrong. Try signing out and back in, and try again.", comment: "")
     static let errorInCreation = NSLocalizedString("Could not finish request. Check your internet connection and try again.", comment: "")
-    static let thanks = NSLocalizedString("Thank you! Your dependent should receive the invitation shortly if the email was entered correctly.", comment: "")
+    static let thanks = NSLocalizedString("Your dependent should receive the invitation soon.\n\nAdvise them to open the link in the email on their device and create a passkey. This will make logging in easier.", comment: "")
     static let guideText = NSLocalizedString("Fill in an email where the invitation should be sent. Make sure to type it correctly before sending.", comment: "")
     static let successButton = NSLocalizedString("Invite sent!", comment: "")
 

--- a/Palace/Utilities/Localization/Strings.swift
+++ b/Palace/Utilities/Localization/Strings.swift
@@ -132,7 +132,9 @@ struct Strings {
     static let enterEmail = NSLocalizedString("Enter email of a Dependent: ", comment: "")
     static let incorrectEmail = NSLocalizedString("Incorrect email", comment: "")
     static let sendButton = NSLocalizedString("Send invite", comment: "")
-    
+    static let selectADependent = NSLocalizedString("Select a dependent", comment: "")
+    static let noDependents = NSLocalizedString("No dependents found", comment: "")
+
   }
   
   struct Preferences {

--- a/Palace/Utilities/Localization/Strings.swift
+++ b/Palace/Utilities/Localization/Strings.swift
@@ -127,13 +127,18 @@ struct Strings {
     static let dependentsButton = NSLocalizedString("Invite a Dependent", comment: "")
     static let dependents = NSLocalizedString("Dependents", comment: "")
     static let getDependents = NSLocalizedString("Get Dependents", comment: "")
-    static let select = NSLocalizedString("Select", comment: "")
+    static let select = NSLocalizedString("Select:", comment: "")
     static let selected = NSLocalizedString("Selected Dependent is: ", comment: "")
-    static let enterEmail = NSLocalizedString("Enter email of a Dependent: ", comment: "")
+    static let enterEmail = NSLocalizedString("Enter email: ", comment: "")
     static let incorrectEmail = NSLocalizedString("Incorrect email", comment: "")
     static let sendButton = NSLocalizedString("Send invite", comment: "")
     static let selectADependent = NSLocalizedString("Select a dependent", comment: "")
-    static let noDependents = NSLocalizedString("No dependents found", comment: "")
+    static let noDependents = NSLocalizedString("No dependents or children found.", comment: "")
+    static let errorFromServer = NSLocalizedString("Something went wrong. Try signing out and back in, and try again.", comment: "")
+    static let errorInCreation = NSLocalizedString("Could not finish request. Check your internet connection and try again.", comment: "")
+    static let thanks = NSLocalizedString("Thank you! Your dependent should receive the invitation shortly if the email was entered correctly.", comment: "")
+    static let guideText = NSLocalizedString("Fill in an email where the invitation should be sent. Make sure to type it correctly before sending.", comment: "")
+    static let successButton = NSLocalizedString("Invite sent!", comment: "")
 
   }
   


### PR DESCRIPTION
This PR enables a user to send an invite to their selected dependent:
- Stores the user's patron id during authentication
- Makes a get request to circulation to get a valid ekirjasto token
- Makes a get request to Loikka using the ekirjasto token to fetch any dependents (relations)
- Shows the user a picker from which to select one of their dependents
- Enables the user to type in an email to where the invite should be sent to
- Validates the email
- Finally makes a post request to Loikka containing the dependents information and sends an invite email to the given email
- Any errors or fails during this process are caught and the user is informed with an appropriate alert (usually a problem with an expired ekirjasto token or a bad internet connection)
- A success message is shown once the invite has been sent successfully