### PR TITLE
Fix missing custom fonts

### DIFF
--- a/Palace/Settings/NewSettings/DependentsView.swift
+++ b/Palace/Settings/NewSettings/DependentsView.swift
@@ -83,6 +83,7 @@ struct DependentsView: View {
         } header: {
           HStack{
             Text(tsx.dependents)
+              .font(Font(uiFont: UIFont.palaceFont(ofSize: 16)))
             Spacer()
               .aspectRatio(contentMode: .fit)
               .frame(width: 200)
@@ -98,6 +99,7 @@ struct DependentsView: View {
             } label: {
               HStack{
                 Text(tsx.getDependents)
+                  .font(Font(uiFont: UIFont.palaceFont(ofSize: 16)))
                 Spacer()
                 Image("ArrowRight")
                   .padding(.leading, 10)
@@ -116,6 +118,7 @@ struct DependentsView: View {
                   // If the user doesn't have any dependents, inform them
                   if fetchedDependents.isEmpty {
                     Text(tsx.noDependents).tag(tsx.noDependents)
+                      .font(Font(uiFont: UIFont.palaceFont(ofSize: 16)))
                       .padding()
                     
                     // If a list of dependents is returned, show them in a picker
@@ -135,6 +138,7 @@ struct DependentsView: View {
               .alert(isPresented: $showAlert) {
                 Alert(title: Text(tsxgeneric.error), message: Text(alertMessage), dismissButton: .default(Text(tsxgeneric.ok)))
               }
+              .font(Font(uiFont: UIFont.palaceFont(ofSize: 16)))
             }
           }
         }
@@ -144,10 +148,11 @@ struct DependentsView: View {
           VStack {
             Text(tsx.guideText)
               .foregroundStyle(Color(uiColor: .lightGray))
-              .font(.subheadline)
+              .font(Font(uiFont: UIFont.palaceFont(ofSize: 16)))
               .padding()
               .frame(maxWidth: .infinity, alignment: .leading)
             TextField(tsx.enterEmail, text: $inputEmail)
+              .font(Font(uiFont: UIFont.palaceFont(ofSize: 16)))
               .padding()
               .border(Color(uiColor: .lightGray), width: 1)
               .cornerRadius(3)
@@ -162,6 +167,7 @@ struct DependentsView: View {
             } label: {
               HStack {
                 Text(tsx.sendButton)
+                  .font(Font(uiFont: UIFont.palaceFont(ofSize: 16)))
                 Image("ArrowRight")
                   .padding(.leading, 10)
                   .foregroundColor(Color(uiColor: .lightGray))

--- a/Palace/Settings/NewSettings/TPPSettingsView.swift
+++ b/Palace/Settings/NewSettings/TPPSettingsView.swift
@@ -221,6 +221,7 @@ struct TPPSettingsView: View {
          DependentsView()){
            Text(DisplayStrings.dependentsButton)
          }
+         .font(Font(uiFont: UIFont.palaceFont(ofSize: 16)))
    }
   }
   


### PR DESCRIPTION
**What's this do?**
Add missing custom fonts for some texts.

**Why are we doing this? (w/ Notion link if applicable)**
To enable in-app font size scaling, this custom font needs to be defined for all texts. Plus we also want to have the same font everywhere, right?

**How should this be tested? / Do these changes have associated tests?**
Check the dependents and settings pages, they should now show text size changes when the size is changed in preferences.

**Did someone actually run this code to verify it works?**
I hope so, at least me.