### PR TITLE
Keep debug symbols in debug versions.

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -79,6 +79,7 @@ platform :ios do
       project: "Palace.xcodeproj",
       scheme: "Ekirjasto",
       configuration: "Debug-#{configuration}",
+      include_symbols: true,
       skip_package_ipa: true,
       skip_archive: true,
       skip_codesigning: true,


### PR DESCRIPTION
**What's this do?**
Let's put debug back to debug.