### PR TITLE
EKIRJASTO-77 Remove logo from view Browse books

### DIFF
--- a/Palace/Catalog/TPPCatalogUngroupedFeedViewController.m
+++ b/Palace/Catalog/TPPCatalogUngroupedFeedViewController.m
@@ -109,7 +109,6 @@ static const CGFloat kCollectionViewCrossfadeDuration = 0.3;
   self.facetBarView.facetView.delegate = self;
   self.facetBarView.facetView.dataSource = self.facetViewDataSource;
   
-  [self.facetBarView removeLogo]; //Added by Ellibs
   [self.view addSubview:self.facetBarView];
   [self.facetBarView autoPinEdgeToSuperviewEdge:ALEdgeLeading];
   [self.facetBarView autoPinEdgeToSuperviewEdge:ALEdgeTrailing];

--- a/Palace/Holds/TPPHoldsViewController.m
+++ b/Palace/Holds/TPPHoldsViewController.m
@@ -113,7 +113,6 @@
 
   self.facetBarView = [[TPPFacetBarView alloc] initWithOrigin:CGPointZero width:self.view.bounds.size.width];
   self.facetBarView.delegate = self;
-  [self.facetBarView removeLogo]; //Added by Ellibs
   
   [self.view addSubview:self.facetBarView];
   

--- a/Palace/Views/TPPFacetBarView.swift
+++ b/Palace/Views/TPPFacetBarView.swift
@@ -49,18 +49,7 @@ import Foundation
         
     container.autoPinEdgesToSuperviewEdges(with: UIEdgeInsets(top: 0.0, left: 0.0, bottom: 0.0, right: 0.0))
     imageHolder.autoPinEdgesToSuperviewEdges(with: UIEdgeInsets(top: 10.0, left: 0.0, bottom: 0.0, right: 0.0), excludingEdge: .trailing)
-    
-    //let titleContainer = UIView()
-    //titleContainer.addSubview(titleLabel)
-    //titleLabel.autoPinEdgesToSuperviewEdges()
-    
-    //container.addSubview(titleContainer)
-    //titleContainer.autoPinEdgesToSuperviewEdges(with: UIEdgeInsets(top: 10.0, left: 10.0, bottom: 10.0, right: 10.0), excludingEdge: .leading)
-    //titleContainer.autoPinEdge(.leading, to: .trailing, of: imageView, withOffset: 10.0)
-    
-    //logoView.addSubview(accountSiteButton)
-    //accountSiteButton.autoPinEdgesToSuperviewEdges()
-    //accountSiteButton.addTarget(self, action: #selector(showAccountPage), for: .touchUpInside)
+
     return logoView
   }()
   
@@ -106,7 +95,6 @@ import Foundation
 
   override func draw(_ rect: CGRect) {
     super.draw(rect)
-    //logoView.layer.cornerRadius = logoView.frame.height/2
   }
 
   private func setupViews() {
@@ -136,7 +124,6 @@ import Foundation
 
   @objc func updateLogo() {
     imageView.image = UIImage(named: "LaunchImageLogo")
-    //titleLabel.text = AccountsManager.shared.currentAccount?.name
   }
   
   @objc func removeLogo() {

--- a/Palace/Views/TPPFacetBarView.swift
+++ b/Palace/Views/TPPFacetBarView.swift
@@ -4,12 +4,12 @@ import Foundation
   func present(_ viewController: UIViewController)
 }
 
-@objcMembers class TPPFacetBarView : UIView {
-  var entryPointView: TPPEntryPointView = TPPEntryPointView()
- 
-  private let borderHeight = 1.0 / UIScreen.main.scale;
-  private let toolbarHeight = CGFloat(40.0);
-
+@objcMembers class TPPFacetBarView: UIView {
+  var entryPointView: TPPEntryPointView = .init()
+  
+  private let borderHeight = 1.0 / UIScreen.main.scale
+  private let toolbarHeight = CGFloat(40.0)
+  
   weak var delegate: TPPFacetBarViewDelegate?
   
   lazy var facetView: TPPFacetView = {
@@ -20,19 +20,20 @@ import Foundation
     
     topBorderView.backgroundColor = UIColor.lightGray.withAlphaComponent(0.9)
     bottomBorderView.backgroundColor = UIColor.lightGray.withAlphaComponent(0.9)
-        
+    
     view.addSubview(bottomBorderView)
     view.addSubview(topBorderView)
-
+    
     bottomBorderView.autoPinEdgesToSuperviewEdges(with: UIEdgeInsets.zero, excludingEdge: .top)
     bottomBorderView.autoSetDimension(.height, toSize: borderHeight)
     topBorderView.autoPinEdgesToSuperviewEdges(with: UIEdgeInsets.zero, excludingEdge: .bottom)
-    topBorderView.autoSetDimension(.height, toSize:borderHeight)
+    topBorderView.autoSetDimension(.height, toSize: borderHeight)
+    
     return view
   }()
   
   @available(*, unavailable)
-  private override init(frame: CGRect) {
+  override private init(frame: CGRect) {
     super.init(frame: frame)
   }
   
@@ -42,8 +43,14 @@ import Foundation
   }
   
   init(origin: CGPoint, width: CGFloat) {
-    
-    super.init(frame: CGRect(x: origin.x, y: origin.y, width: width, height: borderHeight + toolbarHeight + 52.0))
+    super.init(
+      frame: CGRect(
+        x: origin.x,
+        y: origin.y,
+        width: width,
+        height: borderHeight + toolbarHeight + 52.0
+      )
+    )
     
     setupViews()
   }
@@ -51,30 +58,29 @@ import Foundation
   deinit {
     NotificationCenter.default.removeObserver(self)
   }
-
+  
   override func draw(_ rect: CGRect) {
     super.draw(rect)
   }
-
+  
   private func setupViews() {
     backgroundColor = TPPConfiguration.backgroundColor()
-    entryPointView.isHidden = false;
-    facetView.isHidden = true;
-
+    
+    entryPointView.isHidden = false
+    facetView.isHidden = true
+    
     addSubview(facetView)
     addSubview(entryPointView)
-
+    
     setupConstraints()
   }
   
   private func setupConstraints() {
     entryPointView.autoPinEdgesToSuperviewEdges(with: UIEdgeInsets.zero, excludingEdge: .bottom)
-    
     facetView.autoPinEdge(toSuperviewEdge: .leading)
     facetView.autoPinEdge(toSuperviewEdge: .trailing)
     facetView.autoPinEdge(.top, to: .bottom, of: facetView, withOffset: 10.0)
     facetView.autoPinEdge(toSuperviewEdge: .bottom, withInset: 10.0)
-    
     entryPointView.autoPinEdge(.bottom, to: .top, of: facetView)
   }
   

--- a/Palace/Views/TPPFacetBarView.swift
+++ b/Palace/Views/TPPFacetBarView.swift
@@ -1,10 +1,33 @@
+//
+//  TTPFacetBarView.swift
+//
+//  Last edited by E-KIRJASTO October 2024
+//
+
 import Foundation
 
 @objc protocol TPPFacetBarViewDelegate {
   func present(_ viewController: UIViewController)
 }
 
+/*
+ TPPFacetBarView is a UIView that has two subviews:
+  - facetView
+  - entryPointView
+
+ In original Palace project the current library account's logo and name were displayed in a third subview called logoView
+  - E-kirjasto app does not display the logo or name separately in app's basic views (Browse books, My books, Reservations) and the logoView subview was removed from TPPFacetBarView.
+  - Also the functionality to show library details (the account page) when user taps said library logo or name, was removed from E-kirjasto app.
+ */
 @objcMembers class TPPFacetBarView: UIView {
+  
+  /*
+   entryPointView
+    - class TPPEntryPointView
+    - is visible
+    - contains the segmented buttons for filtering the books catalogue in app's Browse books view
+    - see more details of this view in file TPPEntryPointView.swift
+   */
   var entryPointView: TPPEntryPointView = .init()
   
   private let borderHeight = 1.0 / UIScreen.main.scale
@@ -12,6 +35,13 @@ import Foundation
   
   weak var delegate: TPPFacetBarViewDelegate?
   
+  /*
+  facetView
+   - class TPPFacetView
+   - hidden view
+   - the bottom line of the facetView marks the point where the catalogue's book lane title "freezes" for a while, until it's replaced with another lane title
+   - in other words, the facetView prevents the catalogue book lanes from visually sliding under the catalogue filter buttons when user scrolls the catalogue view up or down
+   */
   lazy var facetView: TPPFacetView = {
     let view = TPPFacetView()
     

--- a/Palace/Views/TPPFacetBarView.swift
+++ b/Palace/Views/TPPFacetBarView.swift
@@ -81,8 +81,11 @@ import Foundation
   
   private func setupConstraints() {
     entryPointView.autoPinEdgesToSuperviewEdges(with: UIEdgeInsets.zero, excludingEdge: .bottom)
+    
     facetView.autoPinEdge(toSuperviewEdge: .leading)
     facetView.autoPinEdge(toSuperviewEdge: .trailing)
+    facetView.autoPinEdge(.top, to: .bottom, of: facetView, withOffset: 10.0)
+    facetView.autoPinEdge(toSuperviewEdge: .bottom, withInset: 10.0)
     
     entryPointView.autoPinEdge(.bottom, to: .top, of: facetView)
   }

--- a/Palace/Views/TPPFacetBarView.swift
+++ b/Palace/Views/TPPFacetBarView.swift
@@ -73,7 +73,6 @@ import Foundation
   @available(*, unavailable)
   private override init(frame: CGRect) {
     super.init(frame: frame)
-    NotificationCenter.default.addObserver(self, selector: #selector(updateLogo), name: NSNotification.TPPCurrentAccountDidChange, object: nil)
   }
   
   @available(*, unavailable)
@@ -86,7 +85,6 @@ import Foundation
     super.init(frame: CGRect(x: origin.x, y: origin.y, width: width, height: borderHeight + toolbarHeight + 52.0))
     
     setupViews()
-    NotificationCenter.default.addObserver(self, selector: #selector(updateLogo), name: NSNotification.TPPCurrentAccountDidChange, object: nil)
   }
   
   deinit {
@@ -107,7 +105,6 @@ import Foundation
     addSubview(entryPointView)
 
     setupConstraints()
-    updateLogo()
   }
   
   private func setupConstraints() {
@@ -120,10 +117,6 @@ import Foundation
     logoView.autoPinEdge(toSuperviewEdge: .bottom, withInset: 10.0)
     logoView.autoAlignAxis(.vertical, toSameAxisOf: self, withOffset: -15)
     logoView.autoConstrainAttribute(.width, to: .width, of: self, withMultiplier: 0.8, relation: .lessThanOrEqual)
-  }
-
-  @objc func updateLogo() {
-    imageView.image = UIImage(named: "LaunchImageLogo")
   }
   
   @objc func removeLogo() {

--- a/Palace/Views/TPPFacetBarView.swift
+++ b/Palace/Views/TPPFacetBarView.swift
@@ -7,7 +7,6 @@ import Foundation
 @objcMembers class TPPFacetBarView : UIView {
   var entryPointView: TPPEntryPointView = TPPEntryPointView()
  
-  private let accountSiteButton = UIButton()
   private let borderHeight = 1.0 / UIScreen.main.scale;
   private let toolbarHeight = CGFloat(40.0);
 
@@ -79,10 +78,4 @@ import Foundation
     entryPointView.autoPinEdge(.bottom, to: .top, of: facetView)
   }
   
-  @objc private func showAccountPage() {
-    guard let homePageUrl = AccountsManager.shared.currentAccount?.homePageUrl, let url = URL(string: homePageUrl) else { return }
-    let webController = BundledHTMLViewController(fileURL: url, title: AccountsManager.shared.currentAccount?.name.capitalized ?? "")
-    webController.hidesBottomBarWhenPushed = true
-    delegate?.present(webController)
-  }
 }

--- a/Palace/Views/TPPFacetBarView.swift
+++ b/Palace/Views/TPPFacetBarView.swift
@@ -32,27 +32,6 @@ import Foundation
     return view
   }()
   
-  private lazy var logoView: UIView = {
-    let logoView = UIView()
-    logoView.backgroundColor = TPPConfiguration.readerBackgroundColor()
-    
-    let imageHolder = UIView()
-    imageHolder.autoSetDimension(.height, toSize: 40.0)
-    imageHolder.autoSetDimension(.width, toSize: 40.0)
-    imageHolder.addSubview(imageView)
-    
-    imageView.autoPinEdgesToSuperviewEdges()
-    
-    let container = UIView()
-    logoView.addSubview(container)
-    container.addSubview(imageHolder)
-        
-    container.autoPinEdgesToSuperviewEdges(with: UIEdgeInsets(top: 0.0, left: 0.0, bottom: 0.0, right: 0.0))
-    imageHolder.autoPinEdgesToSuperviewEdges(with: UIEdgeInsets(top: 10.0, left: 0.0, bottom: 0.0, right: 0.0), excludingEdge: .trailing)
-
-    return logoView
-  }()
-  
   private lazy var titleLabel: UILabel = {
     let label = UILabel()
     label.lineBreakMode = .byWordWrapping
@@ -62,12 +41,6 @@ import Foundation
     label.textColor = .gray
     label.font = UIFont.boldSystemFont(ofSize: 18.0)
     return label
-  }()
-  
-  private lazy var imageView: UIImageView = {
-    let view = UIImageView(image: UIImage(named: "LaunchImageLogo"))
-    view.contentMode = .scaleAspectFill
-    return view
   }()
   
   @available(*, unavailable)
@@ -101,7 +74,6 @@ import Foundation
     facetView.isHidden = true;
 
     addSubview(facetView)
-    addSubview(logoView)
     addSubview(entryPointView)
 
     setupConstraints()
@@ -113,10 +85,6 @@ import Foundation
     facetView.autoPinEdge(toSuperviewEdge: .trailing)
     
     entryPointView.autoPinEdge(.bottom, to: .top, of: facetView)
-    logoView.autoPinEdge(.top, to: .bottom, of: facetView, withOffset: 10.0)
-    logoView.autoPinEdge(toSuperviewEdge: .bottom, withInset: 10.0)
-    logoView.autoAlignAxis(.vertical, toSameAxisOf: self, withOffset: -15)
-    logoView.autoConstrainAttribute(.width, to: .width, of: self, withMultiplier: 0.8, relation: .lessThanOrEqual)
   }
   
   @objc private func showAccountPage() {

--- a/Palace/Views/TPPFacetBarView.swift
+++ b/Palace/Views/TPPFacetBarView.swift
@@ -119,12 +119,6 @@ import Foundation
     logoView.autoConstrainAttribute(.width, to: .width, of: self, withMultiplier: 0.8, relation: .lessThanOrEqual)
   }
   
-  @objc func removeLogo() {
-    self.logoView.removeFromSuperview()
-    facetView.autoPinEdge(.top, to: .bottom, of: facetView, withOffset: 10.0)   //Added by Ellibs
-    facetView.autoPinEdge(toSuperviewEdge: .bottom, withInset: 10.0)          
-  }
-  
   @objc private func showAccountPage() {
     guard let homePageUrl = AccountsManager.shared.currentAccount?.homePageUrl, let url = URL(string: homePageUrl) else { return }
     let webController = BundledHTMLViewController(fileURL: url, title: AccountsManager.shared.currentAccount?.name.capitalized ?? "")

--- a/Palace/Views/TPPFacetBarView.swift
+++ b/Palace/Views/TPPFacetBarView.swift
@@ -32,17 +32,6 @@ import Foundation
     return view
   }()
   
-  private lazy var titleLabel: UILabel = {
-    let label = UILabel()
-    label.lineBreakMode = .byWordWrapping
-    label.numberOfLines = 0
-    label.textAlignment = .center
-    label.text = AccountsManager.shared.currentAccount?.name
-    label.textColor = .gray
-    label.font = UIFont.boldSystemFont(ofSize: 18.0)
-    return label
-  }()
-  
   @available(*, unavailable)
   private override init(frame: CGRect) {
     super.init(frame: frame)


### PR DESCRIPTION
- The user now sees more books when she/he opens the main view of the application
   - the E-kirjasto logo was removed from the application's _Browse books_ view, leaving more space for displaying book rows
   - the book rows moved up in the view and now start directly below the filter buttons for the different book formats