### PR TITLE
Ekirjasto 92 Fix font size changes in UITabBar

### DIFF
--- a/Palace/AppInfrastructure/TPPAppDelegate.swift
+++ b/Palace/AppInfrastructure/TPPAppDelegate.swift
@@ -82,7 +82,8 @@ class TPPAppDelegate: UIResponder, UIApplicationDelegate {
     UITabBar.appearance().standardAppearance = appearance
     UITabBar.appearance().tintColor = TPPConfiguration.compatiblePrimaryColor() //Edited by Ebblis
     UITabBar.appearance().backgroundColor = TPPConfiguration.backgroundColor()
-    UITabBarItem.appearance().setTitleTextAttributes([.font: UIFont.palaceFont(ofSize: 12)], for: .normal)
+    
+    adjustTabBarItemTitles()
     
     UINavigationBar.appearance().tintColor = TPPConfiguration.iconColor()
     UINavigationBar.appearance().standardAppearance = TPPConfiguration.defaultAppearance()
@@ -185,4 +186,29 @@ class TPPAppDelegate: UIResponder, UIApplicationDelegate {
     }
   }
   
+  /**
+   Adjusts the titles of the tab bar items in UITabBarController based on their calculated sizes.
+   
+   If the calculated height of the title exceeds a defined threshold, the title is removed to prevent overlap,
+   especially on smaller screens. Otherwise, the function sets the title's font size to the scaled size.
+   */
+  func adjustTabBarItemTitles() {
+    if let tabBarController = window?.rootViewController as? UITabBarController {
+      let fontSize: CGFloat = 12
+      let thresholdFontSize: CGFloat = 18 // In smaller screens like SE, anything >18 starts to overlap
+      let font = UIFont.palaceFont(ofSize: fontSize)
+      
+      for item in tabBarController.tabBar.items ?? [] {
+        if let title = item.title {
+          // Remove title text when the threshold is exceeded
+          if font.pointSize >= thresholdFontSize {
+            item.title = ""
+          } else {
+            // Set the title size according to the scaled size
+            item.setTitleTextAttributes([.font: UIFont.palaceFont(ofSize: fontSize)], for: .normal)
+          }
+        }
+      }
+    }
+  }
 }

--- a/Palace/AppInfrastructure/TPPAppDelegate.swift
+++ b/Palace/AppInfrastructure/TPPAppDelegate.swift
@@ -68,9 +68,14 @@ class TPPAppDelegate: UIResponder, UIApplicationDelegate {
     let paragraphStyle = NSMutableParagraphStyle()
     paragraphStyle.lineBreakMode = .byTruncatingTail
     paragraphStyle.allowsDefaultTighteningForTruncation = false
+
+    // iPads have more space so set the font to be larger than in iPhones
+    let fontSize = UIDevice.current.userInterfaceIdiom == .pad ? 18.0 : 12.0
+    let font = UIFontMetrics.default.scaledFont(for: UIFont(name: TPPConfiguration.ekirjastoFontName(), size: fontSize) ?? UIFont.systemFont(ofSize: fontSize))
+    let foregroundColor = TPPConfiguration.compatiblePrimaryColor()
     itemAppearance.normal.titleTextAttributes = [
-      .foregroundColor: TPPConfiguration.compatiblePrimaryColor(),
-      .font: UIFont.palaceFont(ofSize: 12),
+      .foregroundColor: foregroundColor,
+      .font: font,
       .paragraphStyle: paragraphStyle
     ]
     
@@ -82,8 +87,6 @@ class TPPAppDelegate: UIResponder, UIApplicationDelegate {
     UITabBar.appearance().standardAppearance = appearance
     UITabBar.appearance().tintColor = TPPConfiguration.compatiblePrimaryColor() //Edited by Ebblis
     UITabBar.appearance().backgroundColor = TPPConfiguration.backgroundColor()
-    
-    adjustTabBarItemTitles()
     
     UINavigationBar.appearance().tintColor = TPPConfiguration.iconColor()
     UINavigationBar.appearance().standardAppearance = TPPConfiguration.defaultAppearance()
@@ -183,32 +186,6 @@ class TPPAppDelegate: UIResponder, UIApplicationDelegate {
   func signingIn(_ notification: Notification) {
     if let boolValue = notification.object as? Bool {
       self.isSigningIn = boolValue
-    }
-  }
-  
-  /**
-   Adjusts the titles of the tab bar items in UITabBarController based on their calculated sizes.
-   
-   If the calculated height of the title exceeds a defined threshold, the title is removed to prevent overlap,
-   especially on smaller screens. Otherwise, the function sets the title's font size to the scaled size.
-   */
-  func adjustTabBarItemTitles() {
-    if let tabBarController = window?.rootViewController as? UITabBarController {
-      let fontSize: CGFloat = 12
-      let thresholdFontSize: CGFloat = 18 // In smaller screens like SE, anything >18 starts to overlap
-      let font = UIFont.palaceFont(ofSize: fontSize)
-      
-      for item in tabBarController.tabBar.items ?? [] {
-        if let title = item.title {
-          // Remove title text when the threshold is exceeded
-          if font.pointSize >= thresholdFontSize {
-            item.title = ""
-          } else {
-            // Set the title size according to the scaled size
-            item.setTitleTextAttributes([.font: UIFont.palaceFont(ofSize: fontSize)], for: .normal)
-          }
-        }
-      }
     }
   }
 }

--- a/Palace/AppInfrastructure/TPPRootTabBarController.m
+++ b/Palace/AppInfrastructure/TPPRootTabBarController.m
@@ -102,8 +102,7 @@
 
 - (void)setTabViewControllersInternal
 {
-  Account *const currentAccount = [AccountsManager shared].currentAccount;
-  if (currentAccount.details.supportsReservations) {
+  // E-kirjasto supports reservations (==holds) so that view controller is enabled by default unlike before.
     self.viewControllers = @[self.catalogNavigationController,
                              self.myBooksNavigationController,
                              self.holdsNavigationController,
@@ -114,20 +113,6 @@
                                   @"holdsNavigationController",
                                   @"magazineViewController",
                                   @"settingsViewController"];
-  } else {
-    self.viewControllers = @[self.catalogNavigationController,
-                             self.myBooksNavigationController,
-                             self.magazineViewController,
-                             self.settingsViewController];
-    self.viewControllerNames = @[@"catalogNavigationController",
-                                  @"myBooksNavigationController",
-                                  @"magazineViewController",
-                                  @"settingsViewController"];
-    // Change selected index if the "Reservations" or "Settings" tab is selected
-    if (self.selectedIndex > 1) {
-      self.selectedIndex -= 1;
-    }
-  }
 }
 
 - (void)showAndReloadCatalogViewController

--- a/Palace/Catalog/TPPCatalogGroupedFeedViewController.m
+++ b/Palace/Catalog/TPPCatalogGroupedFeedViewController.m
@@ -274,26 +274,32 @@ static CGFloat const kTableViewCrossfadeDuration = 0.3;
 
 #pragma mark UITableViewDelegate
 
+// Sets the row height in the table view
 - (CGFloat)tableView:(__attribute__((unused)) UITableView *)tableView
 heightForRowAtIndexPath:(__attribute__((unused)) NSIndexPath *)indexPath
 {
   return kRowHeight;
 }
 
+// Sets the section header height in the table view
 - (CGFloat)tableView:(__attribute__((unused)) UITableView *)tableView
 heightForHeaderInSection:(__attribute__((unused)) NSInteger)section
 {
   return kSectionHeaderHeight;
 }
 
+// Sets sections header properties.
 - (UIView *)tableView:(__attribute__((unused)) UITableView *)tableView
 viewForHeaderInSection:(NSInteger const)section
+
+// Creates a section header view in a table view, with a fixed height and a width that spans the entire width of the table view. 
 {
   CGRect const frame = CGRectMake(0, 0, CGRectGetWidth(self.tableView.frame), kSectionHeaderHeight);
   UIView *const view = [[UIView alloc] initWithFrame:frame];
   view.autoresizingMask = UIViewAutoresizingFlexibleWidth;
   view.backgroundColor = [[TPPConfiguration backgroundColor] colorWithAlphaComponent:0.9];
   
+  // Creates a header button that displays the title of a category and allows the user to tap on it to view more books in that category.
   {
     UIButton *const button = [UIButton buttonWithType:UIButtonTypeSystem];
     button.titleLabel.font = [UIFont palaceFontOfSize:21];
@@ -307,6 +313,10 @@ viewForHeaderInSection:(NSInteger const)section
     }
     button.titleLabel.lineBreakMode = NSLineBreakByTruncatingTail;
     button.tag = section;
+    TPPCatalogLane *const lane = self.feed.lanes[button.tag];
+    button.accessibilityLabel = [[NSString alloc] initWithFormat:NSLocalizedString(@"More %@ books", nil), lane.title];
+    button.accessibilityTraits = UIAccessibilityTraitHeader;
+    button.accessibilityHint = NSLocalizedString(@"Tap to view more books in this category", "Descriptive label for screen readers");
     [button addTarget:self
                action:@selector(didSelectCategory:)
      forControlEvents:UIControlEventTouchUpInside];
@@ -314,6 +324,7 @@ viewForHeaderInSection:(NSInteger const)section
     [view addSubview:button];
   }
   
+  // Creates a button with text and arrrow and allows the user to tap on it to view more books in the category.
   {
     UIButton *const button = [UIButton buttonWithType:UIButtonTypeSystem];
     button.titleLabel.font = [UIFont palaceFontOfSize:14]; //Edited by Ellibs
@@ -334,6 +345,7 @@ viewForHeaderInSection:(NSInteger const)section
     button.tag = section;
     TPPCatalogLane *const lane = self.feed.lanes[button.tag];
     button.accessibilityLabel = [[NSString alloc] initWithFormat:NSLocalizedString(@"More %@ books", nil), lane.title];
+    button.accessibilityHint = NSLocalizedString(@"Tap to view more books in this category", "Descriptive label for screen readers");
     button.autoresizingMask = UIViewAutoresizingFlexibleLeftMargin;
     [button addTarget:self
                action:@selector(didSelectCategory:)
@@ -486,6 +498,7 @@ viewForHeaderInSection:(NSInteger const)section
   label.textAlignment = NSTextAlignmentCenter;
   label.font = [UIFont semiBoldPalaceFontOfSize: 16];
   label.text = lane.title;
+  label.accessibilityTraits = UIAccessibilityTraitHeader;
   viewController.navigationItem.titleView = label;
 
   [self.navigationController pushViewController:viewController animated:YES];

--- a/Palace/Catalog/TPPCatalogNavigationController.m
+++ b/Palace/Catalog/TPPCatalogNavigationController.m
@@ -61,7 +61,7 @@
   self.tabBarItem.title = NSLocalizedString(@"Browse Books", nil);
   self.tabBarItem.image = [UIImage imageNamed:@"Catalog"];
   self.tabBarItem.selectedImage = [UIImage imageNamed:@"CatalogSelected"];
-  self.tabBarItem.imageInsets = UIEdgeInsetsMake(8.0, 0.0, -8.0, 0.0);
+  self.tabBarItem.imageInsets = UIEdgeInsetsMake(4.0, 0.0, -4.0, 0.0);
   self.navigationItem.title = NSLocalizedString(@"Browse Books", nil);
   
   [self loadTopLevelCatalogViewController];

--- a/Palace/EkirjastoDigitalMagazine/EkirjastoMagazineNavigationController.swift
+++ b/Palace/EkirjastoDigitalMagazine/EkirjastoMagazineNavigationController.swift
@@ -16,7 +16,7 @@ class EkirjastoMagazineNavigationController: TPPLibraryNavigationController {
     tabBarItem.title = NSLocalizedString("Magazines", comment: "")
     tabBarItem.image = UIImage(named: "Magazines")
     tabBarItem.selectedImage = UIImage(named: "MagazinesSelected")
-    tabBarItem.imageInsets = UIEdgeInsets(top: 8.0, left: 0.0, bottom: -8.0, right: 0.0)
+    tabBarItem.imageInsets = UIEdgeInsets(top: 4.0, left: 0.0, bottom: -4.0, right: 0.0)
     
     NotificationCenter.default.addObserver(self, selector: #selector(currentAccountChanged), name: NSNotification.Name(rawValue: NSNotification.TPPCurrentAccountDidChange.rawValue), object: nil)
   }

--- a/Palace/Holds/TPPHoldsNavigationController.m
+++ b/Palace/Holds/TPPHoldsNavigationController.m
@@ -16,7 +16,8 @@
   
   self.tabBarItem.image = [UIImage imageNamed:@"Holds"];
   self.tabBarItem.selectedImage = [UIImage imageNamed:@"HoldsSelected"];
-  self.tabBarItem.imageInsets = UIEdgeInsetsMake(8.0, 0.0, -8.0, 0.0);
+  self.tabBarItem.imageInsets = UIEdgeInsetsMake(4.0, 0.0, -4.0, 0.0);
+  
   [vc updateBadge];
 
 #ifdef SIMPLYE

--- a/Palace/MyBooks/TPPMyBooksViewController.swift
+++ b/Palace/MyBooks/TPPMyBooksViewController.swift
@@ -15,7 +15,7 @@ class TPPMyBooksViewController: NSObject {
     controller.title = Strings.MyBooksView.navTitle
     controller.tabBarItem.image = UIImage(named: "MyBooks")
     controller.tabBarItem.selectedImage = UIImage(named: "MyBooksSelected")
-    controller.tabBarItem.imageInsets = UIEdgeInsets(top: 8.0, left: 0.0, bottom: -8.0, right: 0.0);
+    controller.tabBarItem.imageInsets = UIEdgeInsets(top: 4.0, left: 0.0, bottom: -4.0, right: 0.0);
     controller.navigationItem.backButtonTitle = NSLocalizedString("Back", comment: "Back button")
     controller.navigationItem.titleView?.tintColor = UIColor(named: "ColorEkirjastoBlack")
     return UINavigationController(rootViewController: controller)

--- a/Palace/Settings/NewSettings/TPPSettingsViewController.swift
+++ b/Palace/Settings/NewSettings/TPPSettingsViewController.swift
@@ -15,7 +15,7 @@ class TPPSettingsViewController: NSObject {
     controller.title = Strings.Settings.settings
     controller.tabBarItem.image = UIImage(named: "Settings")
     controller.tabBarItem.selectedImage = UIImage(named: "SettingsSelected")
-    controller.tabBarItem.imageInsets = UIEdgeInsets(top: 8.0, left: 0.0, bottom: -8.0, right: 0.0);
+    controller.tabBarItem.imageInsets = UIEdgeInsets(top: 4.0, left: 0.0, bottom: -4.0, right: 0.0);
     let navigationController = UINavigationController(rootViewController: controller)
 
     return navigationController


### PR DESCRIPTION
**What's this do?**
The UI tab bar font size is fixed to a certain size depending on the device. Font size does not adapt to the user's font size preferences.

**Why are we doing this?**
Large Content Viewer displays the titles and icons as large text and image as long as dynamic fonts are applied in the font. 
The problem we had before of the UITabBar titles being enlarged when the font size was changed in Preferences, was due to setting the font size twice in TPPAppDelegate.swift.

**How should this be tested?**
Tested in iPhone 15, iPad 10th generation and iPhone SE simulators. Note that I wasn't able to confirm that Large Content Viewer works on iPhone SE.