### PR TITLE
Ekirjasto 104 add accessibility headings

### DIFF
--- a/Palace/Catalog/TPPCatalogGroupedFeedViewController.m
+++ b/Palace/Catalog/TPPCatalogGroupedFeedViewController.m
@@ -274,26 +274,32 @@ static CGFloat const kTableViewCrossfadeDuration = 0.3;
 
 #pragma mark UITableViewDelegate
 
+// Sets the row height in the table view
 - (CGFloat)tableView:(__attribute__((unused)) UITableView *)tableView
 heightForRowAtIndexPath:(__attribute__((unused)) NSIndexPath *)indexPath
 {
   return kRowHeight;
 }
 
+// Sets the section header height in the table view
 - (CGFloat)tableView:(__attribute__((unused)) UITableView *)tableView
 heightForHeaderInSection:(__attribute__((unused)) NSInteger)section
 {
   return kSectionHeaderHeight;
 }
 
+// Sets sections header properties.
 - (UIView *)tableView:(__attribute__((unused)) UITableView *)tableView
 viewForHeaderInSection:(NSInteger const)section
+
+// Creates a section header view in a table view, with a fixed height and a width that spans the entire width of the table view. 
 {
   CGRect const frame = CGRectMake(0, 0, CGRectGetWidth(self.tableView.frame), kSectionHeaderHeight);
   UIView *const view = [[UIView alloc] initWithFrame:frame];
   view.autoresizingMask = UIViewAutoresizingFlexibleWidth;
   view.backgroundColor = [[TPPConfiguration backgroundColor] colorWithAlphaComponent:0.9];
   
+  // Creates a header button that displays the title of a category and allows the user to tap on it to view more books in that category.
   {
     UIButton *const button = [UIButton buttonWithType:UIButtonTypeSystem];
     button.titleLabel.font = [UIFont palaceFontOfSize:21];
@@ -318,6 +324,7 @@ viewForHeaderInSection:(NSInteger const)section
     [view addSubview:button];
   }
   
+  // Creates a button with text and arrrow and allows the user to tap on it to view more books in the category.
   {
     UIButton *const button = [UIButton buttonWithType:UIButtonTypeSystem];
     button.titleLabel.font = [UIFont palaceFontOfSize:14]; //Edited by Ellibs

--- a/Palace/Catalog/TPPCatalogGroupedFeedViewController.m
+++ b/Palace/Catalog/TPPCatalogGroupedFeedViewController.m
@@ -307,6 +307,10 @@ viewForHeaderInSection:(NSInteger const)section
     }
     button.titleLabel.lineBreakMode = NSLineBreakByTruncatingTail;
     button.tag = section;
+    TPPCatalogLane *const lane = self.feed.lanes[button.tag];
+    button.accessibilityLabel = [[NSString alloc] initWithFormat:NSLocalizedString(@"More %@ books", nil), lane.title];
+    button.accessibilityTraits = UIAccessibilityTraitHeader;
+    button.accessibilityHint = NSLocalizedString(@"Tap to view more books in this category", "Descriptive label for screen readers");
     [button addTarget:self
                action:@selector(didSelectCategory:)
      forControlEvents:UIControlEventTouchUpInside];
@@ -334,6 +338,7 @@ viewForHeaderInSection:(NSInteger const)section
     button.tag = section;
     TPPCatalogLane *const lane = self.feed.lanes[button.tag];
     button.accessibilityLabel = [[NSString alloc] initWithFormat:NSLocalizedString(@"More %@ books", nil), lane.title];
+    button.accessibilityHint = NSLocalizedString(@"Tap to view more books in this category", "Descriptive label for screen readers");
     button.autoresizingMask = UIViewAutoresizingFlexibleLeftMargin;
     [button addTarget:self
                action:@selector(didSelectCategory:)
@@ -486,6 +491,7 @@ viewForHeaderInSection:(NSInteger const)section
   label.textAlignment = NSTextAlignmentCenter;
   label.font = [UIFont semiBoldPalaceFontOfSize: 16];
   label.text = lane.title;
+  label.accessibilityTraits = UIAccessibilityTraitHeader;
   viewController.navigationItem.titleView = label;
 
   [self.navigationController pushViewController:viewController animated:YES];


### PR DESCRIPTION
**What's this do?**
This PR adds header information to where it was missing.

In addition, the lane titles and more buttons have accessibility descriptions. Also added some comments to the code.

**Why are we doing this? (w/ Notion link if applicable)**
Accessibility - screen readers

**How should this be tested? / Do these changes have associated tests?**
You can test with Accessibility Inspector: When you target header elements, they now show `Traits` value as heading.

**Have the Transifex translators been notified?**
Yes
