### PR TITLE
Ekirjasto 92 fix UI tab bar text size

### DIFF
--- a/Palace/AppInfrastructure/TPPAppDelegate.swift
+++ b/Palace/AppInfrastructure/TPPAppDelegate.swift
@@ -65,12 +65,19 @@ class TPPAppDelegate: UIResponder, UIApplicationDelegate {
       itemAppearance.normal.titlePositionAdjustment = UIOffset(horizontal: 5.0, vertical:  6.0)
     }
     
+    
     let paragraphStyle = NSMutableParagraphStyle()
     paragraphStyle.lineBreakMode = .byTruncatingTail
     paragraphStyle.allowsDefaultTighteningForTruncation = false
+    
+    // iPads have more space so set the font to be larger than in iPhones
+    let fontSize = UIDevice.current.userInterfaceIdiom == .pad ? 18.0 : 12.0
+    let font = UIFontMetrics.default.scaledFont(for: UIFont(name: TPPConfiguration.ekirjastoFontName(), size: fontSize) ?? UIFont.systemFont(ofSize: fontSize))
+    let foregroundColor = TPPConfiguration.compatiblePrimaryColor()
+    
     itemAppearance.normal.titleTextAttributes = [
-      .foregroundColor: TPPConfiguration.compatiblePrimaryColor(),
-      .font: UIFont.palaceFont(ofSize: 12),
+      .foregroundColor: foregroundColor,
+      .font: font,
       .paragraphStyle: paragraphStyle
     ]
     
@@ -82,7 +89,6 @@ class TPPAppDelegate: UIResponder, UIApplicationDelegate {
     UITabBar.appearance().standardAppearance = appearance
     UITabBar.appearance().tintColor = TPPConfiguration.compatiblePrimaryColor() //Edited by Ebblis
     UITabBar.appearance().backgroundColor = TPPConfiguration.backgroundColor()
-    UITabBarItem.appearance().setTitleTextAttributes([.font: UIFont.palaceFont(ofSize: 12)], for: .normal)
     
     UINavigationBar.appearance().tintColor = TPPConfiguration.iconColor()
     UINavigationBar.appearance().standardAppearance = TPPConfiguration.defaultAppearance()

--- a/Palace/AppInfrastructure/TPPRootTabBarController.m
+++ b/Palace/AppInfrastructure/TPPRootTabBarController.m
@@ -102,8 +102,7 @@
 
 - (void)setTabViewControllersInternal
 {
-  Account *const currentAccount = [AccountsManager shared].currentAccount;
-  if (currentAccount.details.supportsReservations) {
+    // E-kirjasto supports reservations (==holds) so it's check has been removed.
     self.viewControllers = @[self.catalogNavigationController,
                              self.myBooksNavigationController,
                              self.holdsNavigationController,
@@ -114,20 +113,6 @@
                                   @"holdsNavigationController",
                                   @"magazineViewController",
                                   @"settingsViewController"];
-  } else {
-    self.viewControllers = @[self.catalogNavigationController,
-                             self.myBooksNavigationController,
-                             self.magazineViewController,
-                             self.settingsViewController];
-    self.viewControllerNames = @[@"catalogNavigationController",
-                                  @"myBooksNavigationController",
-                                  @"magazineViewController",
-                                  @"settingsViewController"];
-    // Change selected index if the "Reservations" or "Settings" tab is selected
-    if (self.selectedIndex > 1) {
-      self.selectedIndex -= 1;
-    }
-  }
 }
 
 - (void)showAndReloadCatalogViewController

--- a/Palace/Catalog/TPPCatalogNavigationController.m
+++ b/Palace/Catalog/TPPCatalogNavigationController.m
@@ -61,7 +61,7 @@
   self.tabBarItem.title = NSLocalizedString(@"Browse Books", nil);
   self.tabBarItem.image = [UIImage imageNamed:@"Catalog"];
   self.tabBarItem.selectedImage = [UIImage imageNamed:@"CatalogSelected"];
-  self.tabBarItem.imageInsets = UIEdgeInsetsMake(8.0, 0.0, -8.0, 0.0);
+  self.tabBarItem.imageInsets = UIEdgeInsetsMake(4.0, 0.0, -7.0, 0.0);
   self.navigationItem.title = NSLocalizedString(@"Browse Books", nil);
   
   [self loadTopLevelCatalogViewController];

--- a/Palace/EkirjastoDigitalMagazine/EkirjastoMagazineNavigationController.swift
+++ b/Palace/EkirjastoDigitalMagazine/EkirjastoMagazineNavigationController.swift
@@ -16,7 +16,7 @@ class EkirjastoMagazineNavigationController: TPPLibraryNavigationController {
     tabBarItem.title = NSLocalizedString("Magazines", comment: "")
     tabBarItem.image = UIImage(named: "Magazines")
     tabBarItem.selectedImage = UIImage(named: "MagazinesSelected")
-    tabBarItem.imageInsets = UIEdgeInsets(top: 8.0, left: 0.0, bottom: -8.0, right: 0.0)
+    tabBarItem.imageInsets = UIEdgeInsets(top: 4.0, left: 0.0, bottom: -4.0, right: 0.0)
     
     NotificationCenter.default.addObserver(self, selector: #selector(currentAccountChanged), name: NSNotification.Name(rawValue: NSNotification.TPPCurrentAccountDidChange.rawValue), object: nil)
   }

--- a/Palace/Holds/TPPHoldsNavigationController.m
+++ b/Palace/Holds/TPPHoldsNavigationController.m
@@ -16,7 +16,7 @@
   
   self.tabBarItem.image = [UIImage imageNamed:@"Holds"];
   self.tabBarItem.selectedImage = [UIImage imageNamed:@"HoldsSelected"];
-  self.tabBarItem.imageInsets = UIEdgeInsetsMake(8.0, 0.0, -8.0, 0.0);
+  self.tabBarItem.imageInsets = UIEdgeInsetsMake(4.0, 0.0, -4.0, 0.0);
   [vc updateBadge];
 
 #ifdef SIMPLYE

--- a/Palace/MyBooks/TPPMyBooksViewController.swift
+++ b/Palace/MyBooks/TPPMyBooksViewController.swift
@@ -15,7 +15,7 @@ class TPPMyBooksViewController: NSObject {
     controller.title = Strings.MyBooksView.navTitle
     controller.tabBarItem.image = UIImage(named: "MyBooks")
     controller.tabBarItem.selectedImage = UIImage(named: "MyBooksSelected")
-    controller.tabBarItem.imageInsets = UIEdgeInsets(top: 8.0, left: 0.0, bottom: -8.0, right: 0.0);
+    controller.tabBarItem.imageInsets = UIEdgeInsets(top: 4.0, left: 0.0, bottom: -4.0, right: 0.0);
     controller.navigationItem.backButtonTitle = NSLocalizedString("Back", comment: "Back button")
     controller.navigationItem.titleView?.tintColor = UIColor(named: "ColorEkirjastoBlack")
     return UINavigationController(rootViewController: controller)

--- a/Palace/Settings/NewSettings/TPPSettingsViewController.swift
+++ b/Palace/Settings/NewSettings/TPPSettingsViewController.swift
@@ -15,7 +15,7 @@ class TPPSettingsViewController: NSObject {
     controller.title = Strings.Settings.settings
     controller.tabBarItem.image = UIImage(named: "Settings")
     controller.tabBarItem.selectedImage = UIImage(named: "SettingsSelected")
-    controller.tabBarItem.imageInsets = UIEdgeInsets(top: 8.0, left: 0.0, bottom: -8.0, right: 0.0);
+    controller.tabBarItem.imageInsets = UIEdgeInsets(top: 4.0, left: 0.0, bottom: -4.0, right: 0.0);
     let navigationController = UINavigationController(rootViewController: controller)
 
     return navigationController


### PR DESCRIPTION
**What's this do?**
The UI tab bar font size is fixed to a certain size depending on the device. Font size does not adapt to the user's font size preferences.

**Why are we doing this?**
Large Content Viewer displays the titles and icons as large text and image as long as dynamic fonts are applied in the font. 
The problem we had before of the UITabBar titles being enlarged when the font size was changed in Preferences, was due to setting the font size twice in TPPAppDelegate.swift.

**How should this be tested?**
Tested in iPhone 15, iPad 10th generation and iPhone SE simulators. Note that I wasn't able to confirm that Large Content Viewer works on iPhone SE.
