### PR TITLE
disable sample/preview in BookDetailView

### DIFF
--- a/Palace/Book/UI/TPPBookDetailView.m
+++ b/Palace/Book/UI/TPPBookDetailView.m
@@ -212,7 +212,7 @@ static NSString *DetailHTMLTemplate = nil;
 
 - (void)createButtonsView
 {
-  self.buttonsView = [[TPPBookButtonsView alloc] initWithSamplesEnabled: YES];
+  self.buttonsView = [[TPPBookButtonsView alloc] initWithSamplesEnabled: NO];
   [self.buttonsView configureForBookDetailsContext];
   self.buttonsView.translatesAutoresizingMaskIntoConstraints = NO;
   self.buttonsView.showReturnButtonIfApplicable = YES;


### PR DESCRIPTION
**What's this do?**
This change disables the sample/preview functionality in the book detail view by setting `samplesEnabled` to `NO` in `TPPBookDetailView`. 

**How should this be tested?**
- Verify book detail view loads correctly
- Confirm `"View Sample"` `"Katso näyte"` `"Visa utdrag"`  button is not visible in (English) material.
- Check that all other book detail buttons function normally

**Did someone actually run this code to verify it works?**
Dev/prod builds tested with:
* iPhone 13 Pro (18.1.1)
* iPhone 6s (15.5)-simulator
* iPhone 13 (15.5)-simulator