### PR TITLE
EKIRJASTO-102 Improve contrast in catalog filter buttons

### DIFF
--- a/Palace/AppInfrastructure/TPPConfiguration+Ekirjasto.swift
+++ b/Palace/AppInfrastructure/TPPConfiguration+Ekirjasto.swift
@@ -174,4 +174,13 @@ extension TPPConfiguration {
       return .lightGray
     }
   }
+  
+  @objc static func catalogSegmentedControlBackgroundColorNormal() -> UIColor {
+    if #available(iOS 13, *) {
+      return UIColor(named: "ColorEkirjastoFilterButtonBackgroundNormal")!
+    } else {
+      return .lightGray
+    }
+  }
+    
 }

--- a/Palace/EkirjastoConfig/Colors.xcassets/ColorEkirjastoFilterButtonBackgroundNormal.colorset/Contents.json
+++ b/Palace/EkirjastoConfig/Colors.xcassets/ColorEkirjastoFilterButtonBackgroundNormal.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xC6",
+          "green" : "0xC6",
+          "red" : "0xC6"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x12",
+          "green" : "0x12",
+          "red" : "0x12"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Palace/Views/TPPEntryPointView.swift
+++ b/Palace/Views/TPPEntryPointView.swift
@@ -45,6 +45,14 @@ final class TPPEntryPointView: UIView {
     }
 
     let segmentedControl = UISegmentedControl(items: titles)
+    
+    // Set style for the filter button group in top of the book catalog in "Browse books" view.
+    // Segmented control button can be in two states
+    //   - selected: button is currently selected
+    //   - normal: button is not selected
+    // Use special darker background color for the buttons that are in normal state to add more contrast.
+    segmentedControl.backgroundColor = TPPConfiguration.catalogSegmentedControlBackgroundColorNormal()
+    
     setupSubviews(segmentedControl)
     isHidden = false;
   }


### PR DESCRIPTION
**What's this do?**
- User can see the filter buttons (buttons with titles "All", "Audiobooks" and "eBooks") in Browse books view more easily
   - the contrast was increased in the button group above the book catalog
   - the selected button stands out more clearly from the non-selected buttons
- The appearance of the segmented control was updated
  - only color changes were made: the background color of normal segments was darkened

**Why are we doing this?**
- To improve app's accessibility

**How should this be tested?**
- Test E-kirjasto app with device's normal and dark mode
