### PR TITLE
EKIRJASTO-117 Update app remote HTML resources + increase project version to 1.2.1

### DIFF
--- a/Palace.xcodeproj/project.pbxproj
+++ b/Palace.xcodeproj/project.pbxproj
@@ -5712,7 +5712,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.1.4;
+				MARKETING_VERSION = 1.2.1;
 				PRODUCT_BUNDLE_IDENTIFIER = "fi.kansalliskirjasto.e-kirjasto";
 				PRODUCT_MODULE_NAME = Palace;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -5777,7 +5777,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.1.4;
+				MARKETING_VERSION = 1.2.1;
 				PRODUCT_BUNDLE_IDENTIFIER = "fi.kansalliskirjasto.e-kirjasto";
 				PROVISIONING_PROFILE_SPECIFIER = "Ad Hoc";
 				RUN_CLANG_STATIC_ANALYZER = YES;
@@ -5831,7 +5831,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.1.4;
+				MARKETING_VERSION = 1.2.1;
 				PRODUCT_BUNDLE_IDENTIFIER = "fi.kansalliskirjasto.e-kirjasto";
 				PRODUCT_MODULE_NAME = Palace;
 				PRODUCT_NAME = "Palace-noDRM";
@@ -6026,7 +6026,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.1.4;
+				MARKETING_VERSION = 1.2.1;
 				PRODUCT_BUNDLE_IDENTIFIER = "fi.kansalliskirjasto.e-kirjasto";
 				PRODUCT_MODULE_NAME = Palace;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -6091,7 +6091,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.1.4;
+				MARKETING_VERSION = 1.2.1;
 				PRODUCT_BUNDLE_IDENTIFIER = "fi.kansalliskirjasto.e-kirjasto";
 				PROVISIONING_PROFILE_SPECIFIER = "Ad Hoc";
 				RUN_CLANG_STATIC_ANALYZER = YES;
@@ -6145,7 +6145,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.1.4;
+				MARKETING_VERSION = 1.2.1;
 				PRODUCT_BUNDLE_IDENTIFIER = "fi.kansalliskirjasto.e-kirjasto";
 				PRODUCT_MODULE_NAME = Palace;
 				PRODUCT_NAME = "Palace-noDRM";
@@ -6340,7 +6340,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.1.4;
+				MARKETING_VERSION = 1.2.1;
 				PRODUCT_BUNDLE_IDENTIFIER = "fi.kansalliskirjasto.e-kirjasto";
 				PRODUCT_MODULE_NAME = Palace;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -6405,7 +6405,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.1.4;
+				MARKETING_VERSION = 1.2.1;
 				PRODUCT_BUNDLE_IDENTIFIER = "fi.kansalliskirjasto.e-kirjasto";
 				PROVISIONING_PROFILE_SPECIFIER = "Ad Hoc";
 				RUN_CLANG_STATIC_ANALYZER = YES;
@@ -6459,7 +6459,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.1.4;
+				MARKETING_VERSION = 1.2.1;
 				PRODUCT_BUNDLE_IDENTIFIER = "fi.kansalliskirjasto.e-kirjasto";
 				PRODUCT_MODULE_NAME = Palace;
 				PRODUCT_NAME = "Palace-noDRM";
@@ -6654,7 +6654,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.1.4;
+				MARKETING_VERSION = 1.2.1;
 				PRODUCT_BUNDLE_IDENTIFIER = "fi.kansalliskirjasto.e-kirjasto";
 				PRODUCT_MODULE_NAME = Palace;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -6719,7 +6719,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.1.4;
+				MARKETING_VERSION = 1.2.1;
 				PRODUCT_BUNDLE_IDENTIFIER = "fi.kansalliskirjasto.e-kirjasto";
 				PROVISIONING_PROFILE_SPECIFIER = "Ad Hoc";
 				RUN_CLANG_STATIC_ANALYZER = YES;
@@ -6773,7 +6773,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.1.4;
+				MARKETING_VERSION = 1.2.1;
 				PRODUCT_BUNDLE_IDENTIFIER = "fi.kansalliskirjasto.e-kirjasto";
 				PRODUCT_MODULE_NAME = Palace;
 				PRODUCT_NAME = "Palace-noDRM";
@@ -6964,7 +6964,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.1.4;
+				MARKETING_VERSION = 1.2.1;
 				PRODUCT_BUNDLE_IDENTIFIER = "fi.kansalliskirjasto.e-kirjasto";
 				PRODUCT_MODULE_NAME = Palace;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -7026,7 +7026,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.1.4;
+				MARKETING_VERSION = 1.2.1;
 				PRODUCT_BUNDLE_IDENTIFIER = "fi.kansalliskirjasto.e-kirjasto";
 				PROVISIONING_PROFILE_SPECIFIER = "App Store";
 				RUN_CLANG_STATIC_ANALYZER = YES;
@@ -7080,7 +7080,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.1.4;
+				MARKETING_VERSION = 1.2.1;
 				PRODUCT_BUNDLE_IDENTIFIER = "fi.kansalliskirjasto.e-kirjasto";
 				PRODUCT_MODULE_NAME = Palace;
 				PRODUCT_NAME = "Palace-noDRM";
@@ -7267,7 +7267,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.1.4;
+				MARKETING_VERSION = 1.2.1;
 				PRODUCT_BUNDLE_IDENTIFIER = "fi.kansalliskirjasto.e-kirjasto";
 				PRODUCT_MODULE_NAME = Palace;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -7329,7 +7329,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.1.4;
+				MARKETING_VERSION = 1.2.1;
 				PRODUCT_BUNDLE_IDENTIFIER = "fi.kansalliskirjasto.e-kirjasto";
 				PROVISIONING_PROFILE_SPECIFIER = "App Store";
 				RUN_CLANG_STATIC_ANALYZER = YES;
@@ -7383,7 +7383,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.1.4;
+				MARKETING_VERSION = 1.2.1;
 				PRODUCT_BUNDLE_IDENTIFIER = "fi.kansalliskirjasto.e-kirjasto";
 				PRODUCT_MODULE_NAME = Palace;
 				PRODUCT_NAME = "Palace-noDRM";
@@ -7570,7 +7570,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.1.4;
+				MARKETING_VERSION = 1.2.1;
 				PRODUCT_BUNDLE_IDENTIFIER = "fi.kansalliskirjasto.e-kirjasto";
 				PRODUCT_MODULE_NAME = Palace;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -7632,7 +7632,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.1.4;
+				MARKETING_VERSION = 1.2.1;
 				PRODUCT_BUNDLE_IDENTIFIER = "fi.kansalliskirjasto.e-kirjasto";
 				PROVISIONING_PROFILE_SPECIFIER = "App Store";
 				RUN_CLANG_STATIC_ANALYZER = YES;
@@ -7686,7 +7686,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.1.4;
+				MARKETING_VERSION = 1.2.1;
 				PRODUCT_BUNDLE_IDENTIFIER = "fi.kansalliskirjasto.e-kirjasto";
 				PRODUCT_MODULE_NAME = Palace;
 				PRODUCT_NAME = "Palace-noDRM";
@@ -7873,7 +7873,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.1.4;
+				MARKETING_VERSION = 1.2.1;
 				PRODUCT_BUNDLE_IDENTIFIER = "fi.kansalliskirjasto.e-kirjasto";
 				PRODUCT_MODULE_NAME = Palace;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -7935,7 +7935,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.1.4;
+				MARKETING_VERSION = 1.2.1;
 				PRODUCT_BUNDLE_IDENTIFIER = "fi.kansalliskirjasto.e-kirjasto";
 				PROVISIONING_PROFILE_SPECIFIER = "App Store";
 				RUN_CLANG_STATIC_ANALYZER = YES;
@@ -7989,7 +7989,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.1.4;
+				MARKETING_VERSION = 1.2.1;
 				PRODUCT_BUNDLE_IDENTIFIER = "fi.kansalliskirjasto.e-kirjasto";
 				PRODUCT_MODULE_NAME = Palace;
 				PRODUCT_NAME = "Palace-noDRM";
@@ -8245,7 +8245,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.1.4;
+				MARKETING_VERSION = 1.2.1;
 				PRODUCT_BUNDLE_IDENTIFIER = "fi.kansalliskirjasto.e-kirjasto";
 				PRODUCT_MODULE_NAME = Palace;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -8307,7 +8307,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.1.4;
+				MARKETING_VERSION = 1.2.1;
 				PRODUCT_BUNDLE_IDENTIFIER = "fi.kansalliskirjasto.e-kirjasto";
 				PRODUCT_MODULE_NAME = Palace;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -8363,7 +8363,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.1.4;
+				MARKETING_VERSION = 1.2.1;
 				PRODUCT_BUNDLE_IDENTIFIER = "fi.kansalliskirjasto.e-kirjasto";
 				PRODUCT_MODULE_NAME = Palace;
 				PRODUCT_NAME = "Palace-noDRM";
@@ -8421,7 +8421,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.1.4;
+				MARKETING_VERSION = 1.2.1;
 				PRODUCT_BUNDLE_IDENTIFIER = "fi.kansalliskirjasto.e-kirjasto";
 				PRODUCT_MODULE_NAME = Palace;
 				PRODUCT_NAME = "Palace-noDRM";
@@ -8611,7 +8611,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.1.4;
+				MARKETING_VERSION = 1.2.1;
 				PRODUCT_BUNDLE_IDENTIFIER = "fi.kansalliskirjasto.e-kirjasto";
 				PROVISIONING_PROFILE_SPECIFIER = "Ad Hoc";
 				RUN_CLANG_STATIC_ANALYZER = YES;
@@ -8671,7 +8671,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.1.4;
+				MARKETING_VERSION = 1.2.1;
 				PRODUCT_BUNDLE_IDENTIFIER = "fi.kansalliskirjasto.e-kirjasto";
 				PROVISIONING_PROFILE_SPECIFIER = "App Store";
 				RUN_CLANG_STATIC_ANALYZER = YES;

--- a/Palace/Settings/NewSettings/TPPSettingsView.swift
+++ b/Palace/Settings/NewSettings/TPPSettingsView.swift
@@ -111,6 +111,7 @@ struct TPPSettingsView: View {
       privacyRow
       softwareLicensesRow
       userAgreementRow
+      instructionsRow
       preferencesRow
     }
   }
@@ -291,6 +292,18 @@ struct TPPSettingsView: View {
     )
   }
   
+  @ViewBuilder private var instructionsRow: some View {
+    navigationLinkRow(
+      title: Strings.Settings.instructions,
+      index: 6,
+      selection: $selectedView,
+      destination: remoteHTMLView(
+        url: TPPSettings.TPPInstructionsURLString,
+        title: Strings.Settings.instructions
+      ).anyView()
+    )
+  }
+
   @ViewBuilder private var preferencesRow: some View {
     navigationLinkRow(
       title: Strings.Preferences.preferencesButton,

--- a/Palace/Settings/NewSettings/TPPSettingsView.swift
+++ b/Palace/Settings/NewSettings/TPPSettingsView.swift
@@ -111,7 +111,6 @@ struct TPPSettingsView: View {
       privacyRow
       softwareLicensesRow
       userAgreementRow
-      faqRow
       preferencesRow
     }
   }
@@ -288,18 +287,6 @@ struct TPPSettingsView: View {
       destination: remoteHTMLView(
         url: TPPSettings.TPPUserAgreementURLString,
         title: Strings.Settings.eula
-      ).anyView()
-    )
-  }
-  
-  @ViewBuilder private var faqRow: some View {
-    navigationLinkRow(
-      title: Strings.Settings.faq,
-      index: 6,
-      selection: $selectedView,
-      destination: remoteHTMLView(
-        url: TPPSettings.TPPFAQURLString,
-        title: Strings.Settings.faq
       ).anyView()
     )
   }

--- a/Palace/Settings/TPPSettings.swift
+++ b/Palace/Settings/TPPSettings.swift
@@ -176,20 +176,58 @@ func feedbackURL(appLanguage: String!) -> String {
   //    - returns the short alphabetical language code as a string
   //    - current possible E-kirjasto app language codes: fi, sv, en
   static let appLanguage = Locale.current.languageCode
-  
+
   // The URL origin shared with remote NatLibFi HTML pages accessed through application
-  //    - the application language code is part of the URL string ('fi' is set as default)
   //    - with the application language code the user is directed to the corresponding language version of the web page
-  //    - example URL origin: 'https://www.kansalliskirjasto.fi/sv/e-kirjasto'
-  static let ekirjastoURLOrigin = "https://www.kansalliskirjasto.fi/\(appLanguage ?? "fi")/e-kirjasto"
+  //    - example URL origin: 'https://www.kansalliskirjasto.fi/sv/e-biblioteket'
 
-  static let TPPAboutPalaceURLString = "http://thepalaceproject.org/"
-  static let TPPUserAgreementURLString = "\(ekirjastoURLOrigin)/e-kirjaston-kayttoehdot"
-  static let TPPPrivacyPolicyURLString = "\(ekirjastoURLOrigin)/e-kirjaston-tietosuoja-ja-rekisteriseloste"
+  // The URL base is same for all NatLibFi HTML pages
+  static let natlibfiOrigin = "https://www.kansalliskirjasto.fi"
+
+  // E-library HTML pages use different path for each language version
+  // Finnish language version is used as default
+  static let elibraryPath = switch appLanguage {
+  case "fi": "fi/e-kirjasto"
+  case "sv": "sv/e-biblioteket"
+  case "en": "en/e-library"
+  default: "fi/e-kirjasto"
+  }
+
+  static let accessibilityResource = switch appLanguage {
+    case "fi": "e-kirjaston-saavutettavuusseloste"
+    case "sv": "e-bibliotekets-tillganglighetsutlatande"
+    case "en": "e-library-accessibility-statement"
+    default: "e-kirjaston-saavutettavuusseloste"
+  }
+
+  static let instructionsResource = switch appLanguage {
+    case "fi": "e-kirjasto-sovelluksen-kayttoohje"
+    case "sv": "anvisningar-e-biblioteket"
+    case "en": "e-library-instructions"
+    default: "e-kirjasto-sovelluksen-kayttoohje"
+  }
+
+  static let privacyPolicyResource = switch appLanguage {
+    case "fi": "e-kirjaston-tietosuoja-ja-rekisteriseloste"
+    case "sv": "dataskydds-och-registerbeskrivning"
+    case "en": "privacy-policy-data-protection-statement-and-description-data-file"
+    default: "e-kirjaston-tietosuoja-ja-rekisteriseloste"
+  }
+
+  static let userAgreementResource = switch appLanguage {
+  case "fi": "e-kirjaston-kayttoehdot"
+  case "sv": "e-bibliotekets-anvandarvillkor"
+  case "en": "e-library-terms-use"
+  default: "e-kirjaston-kayttoehdot"
+  }
+
+  static let TPPAccessibilityURLString = "\(natlibfiOrigin)/\(elibraryPath)/\(accessibilityResource)"
   static let TPPFeedbackURLString = feedbackURL(appLanguage: appLanguage)
-  static let TPPAccessibilityURLString = "\(ekirjastoURLOrigin)/e-kirjaston-saavutettavuusseloste"
+  static let TPPInstructionsURLString = "\(natlibfiOrigin)/\(elibraryPath)/\(instructionsResource)"
+  static let TPPPrivacyPolicyURLString = "\(natlibfiOrigin)/\(elibraryPath)/\(privacyPolicyResource)"
+  static let TPPUserAgreementURLString = "\(natlibfiOrigin)/\(elibraryPath)/\(userAgreementResource)"
 
-  static private let customMainFeedURLKey = "NYPLSettingsCustomMainFeedURL"
+  private static let customMainFeedURLKey = "NYPLSettingsCustomMainFeedURL"
   static private let accountMainFeedURLKey = "NYPLSettingsAccountMainFeedURL"
   static private let userPresentedAgeCheckKey = "NYPLUserPresentedAgeCheckKey"
   static let userHasAcceptedEULAKey = "NYPLSettingsUserAcceptedEULA"

--- a/Palace/Settings/TPPSettings.swift
+++ b/Palace/Settings/TPPSettings.swift
@@ -188,7 +188,6 @@ func feedbackURL(appLanguage: String!) -> String {
   static let TPPPrivacyPolicyURLString = "\(ekirjastoURLOrigin)/e-kirjaston-tietosuoja-ja-rekisteriseloste"
   static let TPPFeedbackURLString = feedbackURL(appLanguage: appLanguage)
   static let TPPAccessibilityURLString = "\(ekirjastoURLOrigin)/e-kirjaston-saavutettavuusseloste"
-  static let TPPFAQURLString = "\(ekirjastoURLOrigin)/e-kirjaston-usein-kysytyt-kysymykset"
 
   static private let customMainFeedURLKey = "NYPLSettingsCustomMainFeedURL"
   static private let accountMainFeedURLKey = "NYPLSettingsAccountMainFeedURL"

--- a/Palace/Utilities/Localization/Strings.swift
+++ b/Palace/Utilities/Localization/Strings.swift
@@ -122,6 +122,7 @@ struct Strings {
     static let signOut = NSLocalizedString("Sign out", comment: "")
     static let loginFooterUserAgreementText = NSLocalizedString("By signing in, you agree the End User License Agreement", comment: "")
     static let faq = NSLocalizedString("FAQ", comment: "")
+    static let instructions = NSLocalizedString("Instructions", comment: "Title of a button that links to a HTML resource containing E-library instructions")
     
     //dependents
     static let dependentsButton = NSLocalizedString("Invite a Dependent", comment: "")
@@ -139,7 +140,6 @@ struct Strings {
     static let thanks = NSLocalizedString("Your dependent should receive the invitation soon.\n\nAdvise them to open the link in the email on their device and create a passkey. This will make logging in easier.", comment: "")
     static let guideText = NSLocalizedString("Fill in an email where the invitation should be sent. Make sure to type it correctly before sending.", comment: "")
     static let successButton = NSLocalizedString("Invite sent!", comment: "")
-
   }
   
   struct Preferences {


### PR DESCRIPTION
**What's this do?**

- User can read and browse the E-kirjasto app user instructions in app
    - User instructions can be accessed from the app's Settings tab
    - Instructions are opened as remote HTML resource (as a web page) in the app
- User instructions are provided in Finnish, Swedish and English in the E-kirjasto NatLibFi web pages
  - instructions web page language version is matched with user's chosen app language FI, SV or EN
- Frequently asked questions HTML resource was removed from the Settings tab and app 

***
**Why are we doing this?**
- Easily accessible user manuals make using the application more comfortable.
- The app user instructions were recently updated in the E-kirjasto web page, so we could replace the FAQ link with a link to the more informative user instructions

***
**How should this be tested?**
Test app Settings tab (in simulator or device) and check that the correct links are opened from buttons.

***
**Have the Transifex translators been notified?**
- [ ] Yes
