### PR TITLE
EKIRJASTO-283 Show favorite books

### DIFF
--- a/Palace.xcodeproj/project.pbxproj
+++ b/Palace.xcodeproj/project.pbxproj
@@ -1017,6 +1017,9 @@
 		73F713572417200F00C63B81 /* TPPBaseReaderViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73F713552417200F00C63B81 /* TPPBaseReaderViewController.swift */; };
 		73F713682417240100C63B81 /* UIViewController+TPP.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73F713672417240100C63B81 /* UIViewController+TPP.swift */; };
 		73FB0AC924EB403D0072E430 /* TPPBookContentTypeConverter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73FB0AC824EB403D0072E430 /* TPPBookContentTypeConverter.swift */; };
+		750732EF2D887261005B2254 /* BookSelectionState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 750732EE2D887258005B2254 /* BookSelectionState.swift */; };
+		750732F02D887261005B2254 /* BookSelectionState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 750732EE2D887258005B2254 /* BookSelectionState.swift */; };
+		750732F12D887261005B2254 /* BookSelectionState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 750732EE2D887258005B2254 /* BookSelectionState.swift */; };
 		7530C8BF2D80C7F90024E184 /* FavoritesView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7530C8BE2D80C7E00024E184 /* FavoritesView.swift */; };
 		7530C8C02D80C7F90024E184 /* FavoritesView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7530C8BE2D80C7E00024E184 /* FavoritesView.swift */; };
 		7530C8C12D80C7F90024E184 /* FavoritesView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7530C8BE2D80C7E00024E184 /* FavoritesView.swift */; };
@@ -1961,6 +1964,7 @@
 		73F713552417200F00C63B81 /* TPPBaseReaderViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = TPPBaseReaderViewController.swift; path = Palace/Reader2/UI/TPPBaseReaderViewController.swift; sourceTree = SOURCE_ROOT; };
 		73F713672417240100C63B81 /* UIViewController+TPP.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = "UIViewController+TPP.swift"; path = "Palace/Reader2/UI/UIViewController+TPP.swift"; sourceTree = SOURCE_ROOT; };
 		73FB0AC824EB403D0072E430 /* TPPBookContentTypeConverter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TPPBookContentTypeConverter.swift; sourceTree = "<group>"; };
+		750732EE2D887258005B2254 /* BookSelectionState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookSelectionState.swift; sourceTree = "<group>"; };
 		7530C8BE2D80C7E00024E184 /* FavoritesView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FavoritesView.swift; sourceTree = "<group>"; };
 		7530C8C22D80C80B0024E184 /* FavoritesMainViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FavoritesMainViewController.swift; sourceTree = "<group>"; };
 		7530C8C62D80CA6E0024E184 /* FavoritesViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FavoritesViewModel.swift; sourceTree = "<group>"; };
@@ -2878,19 +2882,20 @@
 		73B5DFD8260529BE00225C12 /* Models */ = {
 			isa = PBXGroup;
 			children = (
+				750732EE2D887258005B2254 /* BookSelectionState.swift */,
+				E5FC12AD2A24EB1C000BFED5 /* ChapterLocation+Extensions.swift */,
 				E5A1412928D4F1B20091AD2D /* TPPBook.swift */,
-				E5A1413428D94DDA0091AD2D /* TPPContentType.swift */,
 				73B5DFFB26055F8B00225C12 /* TPPBook+Additions.swift */,
+				E523116928504B85007D1DB5 /* TPPBook+Extensions.swift */,
 				E6DA7E9F1F2A718600CFBEC8 /* TPPBookAuthor.swift */,
 				73FB0AC824EB403D0072E430 /* TPPBookContentTypeConverter.swift */,
-				171966A824170819007BB87E /* TPPBookState.swift */,
 				E78AE7F5291BFC6200884446 /* TPPBookCoverRegistry.swift */,
 				E78AE7FF291BFCC600884446 /* TPPBookLocation.swift */,
 				E71A422A29017C58008FC910 /* TPPBookRegistry.swift */,
 				E78AE801291C1D8600884446 /* TPPBookRegistryRecord.swift */,
 				E523124A285C3828007D1DB5 /* TPPBookRegistry+Extensions.swift */,
-				E523116928504B85007D1DB5 /* TPPBook+Extensions.swift */,
-				E5FC12AD2A24EB1C000BFED5 /* ChapterLocation+Extensions.swift */,
+				171966A824170819007BB87E /* TPPBookState.swift */,
+				E5A1413428D94DDA0091AD2D /* TPPContentType.swift */,
 			);
 			path = Models;
 			sourceTree = "<group>";
@@ -4765,6 +4770,7 @@
 				3312637E2A287F53006BA87D /* TPPOPDSAcquisitionAvailability.m in Sources */,
 				3312637F2A287F53006BA87D /* NSError+NYPLAdditions.swift in Sources */,
 				331263802A287F53006BA87D /* TPPReachability.m in Sources */,
+				750732EF2D887261005B2254 /* BookSelectionState.swift in Sources */,
 				331263812A287F53006BA87D /* TPPCatalogLaneCell.m in Sources */,
 				336F0D582A432860009E37F6 /* EkirjastoRoundedLabel.swift in Sources */,
 				331263822A287F53006BA87D /* URLResponse+NYPL.swift in Sources */,
@@ -4986,6 +4992,7 @@
 				E75499F82A1D6863009FF821 /* TPPAppDelegate+Extensions.swift in Sources */,
 				73EB0A7B25821DF4006BC997 /* TPPSignInBusinessLogicUIDelegate.swift in Sources */,
 				73D8D28325A6921400DF5F69 /* Float+TPPAdditions.swift in Sources */,
+				750732F02D887261005B2254 /* BookSelectionState.swift in Sources */,
 				73EB0A7C25821DF4006BC997 /* TPPBookCellCollectionViewController.m in Sources */,
 				21F7D3CC275A9D3C0080B44B /* String+HTMLEntities.swift in Sources */,
 				E75F4A2A29C3AB1F006DFBD8 /* TPPPublicationSpeechSynthesizer.swift in Sources */,
@@ -5358,6 +5365,7 @@
 				E7376EC0287DE9C00095AADF /* CGSize.swift in Sources */,
 				1120749319D20BF9008203A4 /* TPPBookCellCollectionViewController.m in Sources */,
 				0857A0FF247835FF00C7984E /* TPPKeychainStoredVariable.swift in Sources */,
+				750732F12D887261005B2254 /* BookSelectionState.swift in Sources */,
 				111559ED19B8FA590003BE94 /* TPPXML.m in Sources */,
 				E523124B285C3828007D1DB5 /* TPPBookRegistry+Extensions.swift in Sources */,
 				731A5B1224621F2B00B5E663 /* TPPSignInBusinessLogic.swift in Sources */,

--- a/Palace/Accounts/Library/Account.swift
+++ b/Palace/Accounts/Library/Account.swift
@@ -184,6 +184,7 @@ protocol AccountLogoDelegate: AnyObject {
   let userProfileUrl:String?
   let signUpUrl:URL?
   let loansUrl:URL?
+  let selectionUrl: URL?
   var defaultAuth: Authentication? {
     guard auths.count > 1 else { return auths.first }
     return auths.first(where: { !$0.catalogRequiresAuthentication }) ?? auths.first
@@ -244,6 +245,12 @@ protocol AccountLogoDelegate: AnyObject {
     supportsReservations = authenticationDocument.features?.disabled?.contains("https://librarysimplified.org/rel/policy/reservations") != true
     userProfileUrl = authenticationDocument.links?.first(where: { $0.rel == "http://librarysimplified.org/terms/rel/user-profile" })?.href
     loansUrl = URL.init(string: authenticationDocument.links?.first(where: { $0.rel == "http://opds-spec.org/shelf" })?.href ?? "")
+
+    selectionUrl = URL.init(
+      string: authenticationDocument.links?.first(where: {
+        $0.rel == "http://opds-spec.org/shelf/selected_books"
+      })?.href ?? "")
+
     supportsSimplyESync = userProfileUrl != nil
     
     mainColor = authenticationDocument.colorScheme
@@ -402,6 +409,10 @@ protocol AccountLogoDelegate: AnyObject {
     return details?.loansUrl
   }
   
+  var selectionUrl: URL? {
+    return details?.selectionUrl
+  }
+
   init(publication: OPDS2Publication) {
     
     name = publication.metadata.title

--- a/Palace/Book/Models/BookSelectionState.swift
+++ b/Palace/Book/Models/BookSelectionState.swift
@@ -1,0 +1,58 @@
+//
+//  BookSelectionState.swift
+//  E-kirjasto
+//
+
+import Foundation
+
+let SelectedKey = "selected"
+let UnselectedKey = "unselected"
+let SelectionUnregisteredKey = "selectionUnregistered"
+
+@objc public enum BookSelectionState: Int, CaseIterable {
+  case Selected
+  case Unselected
+  case SelectionUnregistered
+
+  init?(_ stringValue: String) {
+    switch stringValue {
+    case SelectedKey:
+      self = .Selected
+    case UnselectedKey:
+      self = .Unselected
+    case SelectionUnregisteredKey:
+      self = .SelectionUnregistered
+    default:
+      return nil
+    }
+  }
+
+  func stringValue() -> String {
+    switch self {
+    case .Selected:
+      return SelectedKey
+    case .Unselected:
+      return UnselectedKey
+    case .SelectionUnregistered:
+      return SelectionUnregisteredKey
+    }
+  }
+}
+
+class BookSelectionStateHelper: NSObject {
+
+  @objc(stringValueFromBookSelectionState:)
+  static func stringValue(from bookSelectionState: BookSelectionState) -> String {
+    return bookSelectionState.stringValue()
+  }
+
+  @objc(bookSelectionStateFromStringValue:)
+  static func bookSelectionState(from stringValue: String) -> NSNumber? {
+    guard let selectionState = BookSelectionState(stringValue) else {
+      return nil
+    }
+
+    return NSNumber(integerLiteral: selectionState.rawValue)
+  }
+
+}

--- a/Palace/Book/Models/TPPBookRegistry.swift
+++ b/Palace/Book/Models/TPPBookRegistry.swift
@@ -10,52 +10,91 @@ import Foundation
 import UIKit
 
 protocol TPPBookRegistryProvider {
-  func setProcessing(_ processing: Bool, for bookIdentifier: String)
+
+  // Getters:
+  func book(forIdentifier bookIdentifier: String) -> TPPBook?
+  func fulfillmentId(forIdentifier bookIdentifier: String) -> String?
+  func location(forIdentifier identifier: String) -> TPPBookLocation?
   func state(for bookIdentifier: String) -> TPPBookState
   func selectionState(for bookIdentifier: String) -> BookSelectionState
-  func readiumBookmarks(forIdentifier identifier: String) -> [TPPReadiumBookmark]
-  func setLocation(_ location: TPPBookLocation?, forIdentifier identifier: String)
-  func location(forIdentifier identifier: String) -> TPPBookLocation?
-  func add(_ bookmark: TPPReadiumBookmark, forIdentifier identifier: String)
-  func delete(_ bookmark: TPPReadiumBookmark, forIdentifier identifier: String)
-  func replace(_ oldBookmark: TPPReadiumBookmark, with newBookmark: TPPReadiumBookmark, forIdentifier identifier: String)
-  func genericBookmarksForIdentifier(_ bookIdentifier: String) -> [TPPBookLocation]
-  func addOrReplaceGenericBookmark(_ location: TPPBookLocation, forIdentifier bookIdentifier: String)
-  func addGenericBookmark(_ location: TPPBookLocation, forIdentifier bookIdentifier: String)
-  func deleteGenericBookmark(_ location: TPPBookLocation, forIdentifier bookIdentifier: String)
-  func replaceGenericBookmark(_ oldLocation: TPPBookLocation, with newLocation: TPPBookLocation, forIdentifier: String)
-  func addBook(_ book: TPPBook, location: TPPBookLocation?, state: TPPBookState, selectionState: BookSelectionState, fulfillmentId: String?, readiumBookmarks: [TPPReadiumBookmark]?, genericBookmarks: [TPPBookLocation]?)
+
+  // Setters:
+  func setFulfillmentId(_ fulfillmentId: String, for bookIdentifier: String)
+  func setLocation(
+    _ location: TPPBookLocation?, forIdentifier identifier: String)
+  func setProcessing(_ processing: Bool, for bookIdentifier: String)
+  func setSelectionState(
+    _ selectionState: BookSelectionState, for bookIdentifier: String)
+  func setState(_ state: TPPBookState, for bookIdentifier: String)
+
+  // Modifiers
+  func addBook(
+    _ book: TPPBook,
+    location: TPPBookLocation?,
+    state: TPPBookState,
+    selectionState: BookSelectionState,
+    fulfillmentId: String?,
+    readiumBookmarks: [TPPReadiumBookmark]?,
+    genericBookmarks: [TPPBookLocation]?
+  )
   func removeBook(forIdentifier bookIdentifier: String)
   func updateBook(_ book: TPPBook, selectionState: BookSelectionState)
   func updateAndRemoveBook(_ book: TPPBook)
-  func setState(_ state: TPPBookState, for bookIdentifier: String)
-  func setSelectionState(_ selectionState: BookSelectionState, for bookIdentifier: String)
-  func book(forIdentifier bookIdentifier: String) -> TPPBook?
-  func fulfillmentId(forIdentifier bookIdentifier: String) -> String?
-  func setFulfillmentId(_ fulfillmentId: String, for bookIdentifier: String)
-  func with(account: String, perform block: (_ registry: TPPBookRegistry) -> Void)
+
+  // Account related:
+  func with(
+    account: String,
+    perform block: (_ registry: TPPBookRegistry) -> Void
+  )
+
+  // Bookmarks related:
+  func add(_ bookmark: TPPReadiumBookmark, forIdentifier identifier: String)
+  func delete(_ bookmark: TPPReadiumBookmark, forIdentifier identifier: String)
+  func replace(
+    _ oldBookmark: TPPReadiumBookmark,
+    with newBookmark: TPPReadiumBookmark,
+    forIdentifier identifier: String
+  )
+  func genericBookmarksForIdentifier(_ bookIdentifier: String)
+    -> [TPPBookLocation]
+  func addOrReplaceGenericBookmark(
+    _ location: TPPBookLocation, forIdentifier bookIdentifier: String)
+  func addGenericBookmark(
+    _ location: TPPBookLocation, forIdentifier bookIdentifier: String)
+  func deleteGenericBookmark(
+    _ location: TPPBookLocation, forIdentifier bookIdentifier: String)
+  func replaceGenericBookmark(
+    _ oldLocation: TPPBookLocation, with newLocation: TPPBookLocation,
+    forIdentifier: String)
+  func readiumBookmarks(forIdentifier identifier: String)
+    -> [TPPReadiumBookmark]
+
 }
 
 typealias TPPBookRegistryData = [String: Any]
 
 extension TPPBookRegistryData {
+
   func value(for key: TPPBookRegistryKey) -> Any? {
     return self[key.rawValue]
   }
+
   mutating func setValue(_ value: Any?, for key: TPPBookRegistryKey) {
     self[key.rawValue] = value
   }
+
   func object(for key: TPPBookRegistryKey) -> TPPBookRegistryData? {
     self[key.rawValue] as? TPPBookRegistryData
   }
+
   func array(for key: TPPBookRegistryKey) -> [TPPBookRegistryData]? {
     self[key.rawValue] as? [TPPBookRegistryData]
   }
+
 }
 
 enum TPPBookRegistryKey: String {
   case records = "records"
-
   case book = "metadata"
   case state = "state"
   case selectionState = "selectionState"
@@ -70,11 +109,14 @@ fileprivate class BoolWithDelay {
   private var switchBackDelay: Double
   private var resetTask: DispatchWorkItem?
   private var onChange: ((_ value: Bool) -> Void)?
-  init(delay: Double = 5, onChange: ((_ value: Bool) -> Void)? = nil) {
+  init(
+    delay: Double = 5,
+    onChange: ((_ value: Bool) -> Void)? = nil
+  ) {
     self.switchBackDelay = delay
     self.onChange = onChange
   }
-  
+
   var value: Bool = false {
     willSet {
       if value != newValue {
@@ -88,7 +130,10 @@ fileprivate class BoolWithDelay {
           self?.value = false
         }
         resetTask = task
-        DispatchQueue.main.asyncAfter(deadline: .now() + switchBackDelay, execute: task)
+        DispatchQueue.main.asyncAfter(
+          deadline: .now() + switchBackDelay,
+          execute: task
+        )
       }
     }
   }
@@ -96,83 +141,105 @@ fileprivate class BoolWithDelay {
 
 @objcMembers
 class TPPBookRegistry: NSObject, TPPBookRegistrySyncing {
-  
+
   @objc
   enum RegistryState: Int {
     case unloaded, loading, loaded, syncing
   }
-  
+
   private let registryFolderName = "registry"
   private let registryFileName = "registry.json"
-  
+
   // Reloads book registry when library account is changed.
-  private var accountDidChange = NotificationCenter.default.publisher(for: .TPPCurrentAccountDidChange)
-    .receive(on: RunLoop.main)
-    .sink { _ in
-      TPPBookRegistry.shared.load()
-      TPPBookRegistry.shared.sync()
-    }
-  
+  private var accountDidChange = NotificationCenter.default.publisher(
+    for: .TPPCurrentAccountDidChange
+  )
+  .receive(on: RunLoop.main)
+  .sink { _ in
+    TPPBookRegistry.shared.load()
+    TPPBookRegistry.shared.sync()
+  }
+
   /// Book registry with book identifiers as keys.
   private var registry = [String: TPPBookRegistryRecord]() {
     didSet {
-      NotificationCenter.default.post(name: .TPPBookRegistryDidChange, object: nil, userInfo: nil)
+      NotificationCenter.default.post(
+        name: .TPPBookRegistryDidChange,
+        object: nil,
+        userInfo: nil
+      )
     }
   }
-  
+
   private var coverRegistry = TPPBookCoverRegistry()
-  
+
   /// Book identifiers that are being processed.
   private var processingIdentifiers = Set<String>()
-  
+
   static let shared = TPPBookRegistry()
-  
+
   /// Identifies that the synchronsiation process is going on.
   private(set) var isSyncing: Bool {
     get {
       syncState.value
     }
-    set { }
+    set {}
   }
-  
+
   /// `syncState` switches back after a delay to prevent locking in synchronization state
   private var syncState = BoolWithDelay { value in
     if value {
-      NotificationCenter.default.post(name: .TPPSyncBegan, object: nil, userInfo: nil)
+      NotificationCenter.default.post(
+        name: .TPPSyncBegan,
+        object: nil,
+        userInfo: nil
+      )
     } else {
-      NotificationCenter.default.post(name: .TPPSyncEnded, object: nil, userInfo: nil)
+      NotificationCenter.default.post(
+        name: .TPPSyncEnded,
+        object: nil,
+        userInfo: nil
+      )
     }
   }
-  
-  private(set) var state: RegistryState  = .unloaded {
+
+  private(set) var state: RegistryState = .unloaded {
     didSet {
       syncState.value = state == .syncing
-      NotificationCenter.default.post(name: .TPPBookRegistryStateDidChange, object: nil, userInfo: nil)
+      NotificationCenter.default.post(
+        name: .TPPBookRegistryStateDidChange,
+        object: nil,
+        userInfo: nil
+      )
     }
   }
-  
+
   /// Keeps loans URL of current synchronisation process.
-  /// TPPBookRegistry is a shared object, this value is used to cancel synchronisation callback when the user changes library account.
+  /// TPPBookRegistry is a shared object,
+  /// this value is used to cancel synchronisation callback when the user changes library account.
   private var syncUrl: URL?
-  
+
   private override init() {
     super.init()
-    
+
   }
-  
+
   fileprivate init(account: String) {
     super.init()
     load(account: account)
   }
-  
+
   /// Performs a block of operations on the provided account.
   /// - Parameters:
   ///   - account: Library account identifier.
   ///   - block: Provides registry object for the provided account.
-  func with(account: String, perform block: (_ registry: TPPBookRegistry) -> Void) {
+  func with(
+    account: String,
+    perform block: (_ registry: TPPBookRegistry) -> Void
+  ) {
     block(TPPBookRegistry(account: account))
   }
-  
+
   /// Registry file URL.
   /// - Parameter account: Library account identifier.
   /// - Returns: Registry file URL.
@@ -181,21 +248,25 @@ class TPPBookRegistry: NSObject, TPPBookRegistrySyncing {
       .appendingPathComponent(registryFolderName)
       .appendingPathComponent(registryFileName)
   }
-  
+
   /// Loads the book registry for the provided library account.
   /// - Parameter account: Library account identifier.
   func load(account: String? = nil) {
+
     guard let account = account ?? AccountsManager.shared.currentAccountId,
-          let registryFileUrl = self.registryUrl(for: account)
+      let registryFileUrl = self.registryUrl(for: account)
     else {
       return
     }
+
     state = .loading
     registry.removeAll()
+
     if FileManager.default.fileExists(atPath: registryFileUrl.path),
       let registryData = try? Data(contentsOf: registryFileUrl),
       let jsonObject = try? JSONSerialization.jsonObject(with: registryData),
-      let registryObject = jsonObject as? TPPBookRegistryData {
+      let registryObject = jsonObject as? TPPBookRegistryData
+    {
       if let records = registryObject.array(for: .records) {
         for recordObject in records {
           guard let record = TPPBookRegistryRecord(record: recordObject) else {
@@ -208,9 +279,10 @@ class TPPBookRegistry: NSObject, TPPBookRegistrySyncing {
         }
       }
     }
+
     state = .loaded
   }
-  
+
   /// Removes registry data.
   /// - Parameter account: Library account identifier.
   func reset(_ account: String) {
@@ -220,15 +292,22 @@ class TPPBookRegistry: NSObject, TPPBookRegistrySyncing {
       do {
         try FileManager.default.removeItem(at: registryUrl)
       } catch {
-        Log.error(#file, "Error deleting registry data: \(error.localizedDescription)")
+        Log.error(
+          #file, "Error deleting registry data: \(error.localizedDescription)")
       }
     }
   }
-  
+
   /// Synchronizes local registry data and current loans data.
-  /// - Parameter completion: Completion handler provides an error document for error handling and a boolean value, indicating the presence of books available for download.
-  func sync(completion: ((_ errorDocument: [AnyHashable: Any]?, _ newBooks: Bool) -> Void)? = nil) {
-    
+  /// - Parameter completion:
+  ///     * Completion handler provides an error document for error handling and a boolean value,
+  ///       indicating the presence of books available for download.
+  func sync(
+    completion: (
+      (_ errorDocument: [AnyHashable: Any]?, _ newBooks: Bool) -> Void
+    )? = nil
+  ) {
+
     guard let loansUrl = AccountsManager.shared.currentAccount?.loansUrl else {
       return
     }
@@ -239,7 +318,8 @@ class TPPBookRegistry: NSObject, TPPBookRegistrySyncing {
     state = .syncing
     syncUrl = loansUrl
     print("book registry syncUrl 1: \(syncUrl as URL?)")
-    TPPOPDSFeed.withURL(loansUrl, shouldResetCache: true) { feed, errorDocument in
+    TPPOPDSFeed.withURL(loansUrl, shouldResetCache: true) {
+      feed, errorDocument in
       print("book registry withURL!")
       DispatchQueue.main.async {
         defer {
@@ -261,10 +341,11 @@ class TPPBookRegistry: NSObject, TPPBookRegistrySyncing {
         if let licensor = feed.licensor as? [String: Any] {
           TPPUserAccount.sharedAccount().setLicensor(licensor)
         }
-        var recordsToDelete = Set<String>(self.registry.keys.map { $0 as String })
+        var recordsToDelete = Set<String>(
+          self.registry.keys.map { $0 as String })
         for entry in feed.entries {
           guard let opdsEntry = entry as? TPPOPDSEntry,
-                let book = TPPBook(entry: opdsEntry)
+            let book = TPPBook(entry: opdsEntry)
           else {
             continue
           }
@@ -275,40 +356,46 @@ class TPPBookRegistry: NSObject, TPPBookRegistrySyncing {
             // book was found -> update the book in registry
             self.updateBook(
               book,
-              selectionState: .Selected // just placeholder code
+              selectionState: .Selected  // just placeholder code
             )
           } else {
             // otherwise -> add the book as new to registry
             self.addBook(
               book,
               state: .DownloadNeeded,
-              selectionState: .Selected // just placeholder code
+              selectionState: .Selected  // just placeholder code
             )
           }
         }
         recordsToDelete.forEach {
-          if let state = self.registry[$0]?.state, state == .DownloadSuccessful || state == .Used {
+          if let state = self.registry[$0]?.state,
+            state == .DownloadSuccessful || state == .Used
+          {
             MyBooksDownloadCenter.shared.deleteLocalContent(for: $0)
           }
           self.registry[$0] = nil
         }
         self.save()
-        
+
         // Count new books
         var readyBooks = 0
         self.heldBooks.forEach { book in
-          book.defaultAcquisition?.availability.matchUnavailable(nil, limited: nil, unlimited: nil, reserved: nil, ready: { _ in
-            readyBooks += 1
-          })
+          book.defaultAcquisition?.availability.matchUnavailable(
+            nil, limited: nil, unlimited: nil, reserved: nil,
+            ready: { _ in
+              readyBooks += 1
+            })
         }
 
         if UIApplication.shared.applicationIconBadgeNumber != readyBooks {
           UIApplication.shared.applicationIconBadgeNumber = readyBooks
 
           let loansAndHoldsTab = TPPRootTabBarController.shared().tabBar.items?[1]
-          let newTabBadgeValue = readyBooks > 0
-          ? "\(readyBooks)"
-          : nil
+          
+          let newTabBadgeValue =
+            readyBooks > 0
+            ? "\(readyBooks)"
+            : nil
 
           loansAndHoldsTab?.badgeValue = newTabBadgeValue
         }
@@ -321,24 +408,29 @@ class TPPBookRegistry: NSObject, TPPBookRegistrySyncing {
   /// Saves book registry data.
   private func save() {
     guard let account = AccountsManager.shared.currentAccount?.uuid,
-          let registryUrl = registryUrl(for: account)
+      let registryUrl = registryUrl(for: account)
     else {
       return
     }
     do {
       if !FileManager.default.fileExists(atPath: registryUrl.path) {
-        try FileManager.default.createDirectory(at: registryUrl.deletingLastPathComponent(), withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(
+          at: registryUrl.deletingLastPathComponent(),
+          withIntermediateDirectories: true)
       }
-      let registryValues = registry.values.map { $0.dictionaryRepresentation } //.withNullValues() }
+      let registryValues = registry.values.map { $0.dictionaryRepresentation }  //.withNullValues() }
       let registryObject = [TPPBookRegistryKey.records.rawValue: registryValues]
-      let registryData = try JSONSerialization.data(withJSONObject: registryObject, options: .fragmentsAllowed)
+      let registryData = try JSONSerialization.data(
+        withJSONObject: registryObject, options: .fragmentsAllowed)
       try registryData.write(to: registryUrl, options: .atomic)
-      NotificationCenter.default.post(name: .TPPBookRegistryDidChange, object: nil, userInfo: nil)
+      NotificationCenter.default.post(
+        name: .TPPBookRegistryDidChange, object: nil, userInfo: nil)
     } catch {
-      Log.error(#file, "Error saving book registry: \(error.localizedDescription)")
+      Log.error(
+        #file, "Error saving book registry: \(error.localizedDescription)")
     }
   }
-  
+
   // For Objective-C code
   func load() {
     load(account: nil)
@@ -347,39 +439,45 @@ class TPPBookRegistry: NSObject, TPPBookRegistrySyncing {
     sync(completion: nil)
   }
 
-  
   // MARK: - Books
-  
-  /// Returns all registered books.
+
+  /// Returns all books in book registry (= registered books)
   var allBooks: [TPPBook] {
     registry
       .map { $0.value }
       .filter { TPPBookStateHelper.allBookStates().contains($0.state.rawValue) }
       .map { $0.book }
   }
-  
-  /// Returns all books that are on hold.
+
+  /// Returns all registered books that are on hold.
   var heldBooks: [TPPBook] {
     registry
       .map { $0.value }
       .filter { $0.state == .Holding }
       .map { $0.book }
   }
-  
-  /// Returns all books on loan (books not on hold).
+
+  /// Returns all registered books that are on loan (and not on hold)
   var loans: [TPPBook] {
     let matchingStates: [TPPBookState] = [
-      .DownloadNeeded, .Downloading, .SAMLStarted, .DownloadFailed, .DownloadSuccessful, .Used
+      .DownloadNeeded,
+      .Downloading,
+      .SAMLStarted,
+      .DownloadFailed,
+      .DownloadSuccessful,
+      .Used,
     ]
-    return registry
+    return
+      registry
       .map { $0.value }
       .filter { matchingStates.contains($0.state) }
       .map { $0.book }
   }
 
-  /// Returns all books that are selected (books that are favorites).
+  /// Returns all registerd books that are selected (= books that are favorites).
   var selectedBooks: [TPPBook] {
-    return registry
+    return
+      registry
       .map { $0.value }
       .filter { $0.selectionState == .Selected }
       .map { $0.book }
@@ -389,11 +487,79 @@ class TPPBookRegistry: NSObject, TPPBookRegistrySyncing {
   /// present information about obtained books when offline. Attempting to add a book already present
   /// will overwrite the existing book as if `updateBook` were called. The location may be nil. The
   /// state provided must be one of `TPPBookState` and must not be `TPPBookState.Unregistered`.
-  func addBook(_ book: TPPBook, location: TPPBookLocation? = nil, state: TPPBookState = .DownloadNeeded, selectionState: BookSelectionState, fulfillmentId: String? = nil, readiumBookmarks: [TPPReadiumBookmark]? = nil, genericBookmarks: [TPPBookLocation]? = nil) {
+  func addBook(
+    _ book: TPPBook,
+    location: TPPBookLocation? = nil,
+    state: TPPBookState = .DownloadNeeded,
+    selectionState: BookSelectionState,
+    fulfillmentId: String? = nil,
+    readiumBookmarks: [TPPReadiumBookmark]? = nil,
+    genericBookmarks: [TPPBookLocation]? = nil
+  ) {
     coverRegistry.pinThumbnailImageForBook(book)
-    print("[TPPBookRegistry.swift: addBook] Adding book \(book.title) with state: \(TPPBookStateHelper.stringValue(from: state)) and selectionState: \(BookSelectionStateHelper.stringValue(from: selectionState))")
-    registry[book.identifier] = TPPBookRegistryRecord(book: book, location: location, state: state, selectionState: selectionState, fulfillmentId: fulfillmentId, readiumBookmarks: readiumBookmarks, genericBookmarks: genericBookmarks)
+
+    print("[TPPBookRegistry.swift: addBook] Adding book \(book.title) to book registry")
+    print("[TPPBookRegistry.swift: addBook] Adding book with state: \(TPPBookStateHelper.stringValue(from: state))")
+    print("[TPPBookRegistry.swift: addBook] Adding book with selectionState: \(BookSelectionStateHelper.stringValue(from: selectionState))")
+
+    registry[book.identifier] = TPPBookRegistryRecord(
+      book: book,
+      location: location,
+      state: state,
+      selectionState: selectionState,
+      fulfillmentId: fulfillmentId,
+      readiumBookmarks: readiumBookmarks,
+      genericBookmarks: genericBookmarks)
     save()
+  }
+  
+  /// Given an identifier, this method removes a book from the registry.
+  func removeBook(forIdentifier bookIdentifier: String) {
+    coverRegistry.removePinnedThumbnailImageForBookIdentifier(bookIdentifier)
+    registry.removeValue(forKey: bookIdentifier)
+    save()
+  }
+  
+  /// This method should be called whenever new book information is retrieved from a server. Doing so
+  /// ensures that once the user has seen the new information, they will continue to do so when
+  /// accessing the application off-line or when viewing books outside of the catalog. Attempts to
+  /// update a book not already stored in the registry will simply be ignored, so it's reasonable to
+  /// call this method whenever new information is obtained regardless of a given book's state.
+  func updateBook(
+    _ book: TPPBook,
+    selectionState: BookSelectionState
+  ) {
+
+    guard let record = registry[book.identifier] else {
+      return
+    }
+
+    TPPUserNotifications.compareAvailability(
+      cachedRecord: record,
+      andNewBook: book
+    )
+
+    // TPPBookRegistryRecord.init() contains logics for correct record updates
+    registry[book.identifier] = TPPBookRegistryRecord(
+      book: book,
+      location: record.location,
+      state: record.state,
+      selectionState: selectionState,
+      fulfillmentId: record.fulfillmentId,
+      readiumBookmarks: record.readiumBookmarks,
+      genericBookmarks: record.genericBookmarks
+    )
+  }
+
+  /// Updates book metadata (e.g., from OPDS feed) in the registry and returns the updated book.
+  func updatedBookMetadata(_ book: TPPBook) -> TPPBook? {
+    guard let bookRecord = registry[book.identifier] else {
+      return nil
+    }
+    let updatedBook = bookRecord.book.bookWithMetadata(from: book)
+    registry[book.identifier]?.book = updatedBook
+    save()
+    return updatedBook
   }
   
   /// This will update the book like updateBook does, but will also set its state to unregistered, then
@@ -408,83 +574,41 @@ class TPPBookRegistry: NSObject, TPPBookRegistrySyncing {
     registry[book.identifier]?.state = .Unregistered
     save()
   }
-
-  /// Given an identifier, this method removes a book from the registry.
-  func removeBook(forIdentifier bookIdentifier: String) {
-    coverRegistry.removePinnedThumbnailImageForBookIdentifier(bookIdentifier)
-    registry.removeValue(forKey: bookIdentifier)
-    save()
+  
+  
+  
+  /// Returns the book for a given identifier if it is registered, else nil.
+  func book(forIdentifier bookIdentifier: String) -> TPPBook? {
+    registry[bookIdentifier]?.book
   }
   
-  /// This method should be called whenever new book information is retrieved from a server. Doing so
-  /// ensures that once the user has seen the new information, they will continue to do so when
-  /// accessing the application off-line or when viewing books outside of the catalog. Attempts to
-  /// update a book not already stored in the registry will simply be ignored, so it's reasonable to
-  /// call this method whenever new information is obtained regardless of a given book's state.
-  func updateBook(_ book: TPPBook, selectionState: BookSelectionState) {
-    guard let record = registry[book.identifier] else {
-      return
-    }
-    TPPUserNotifications.compareAvailability(cachedRecord: record, andNewBook: book)
-    // TPPBookRegistryRecord.init() contains logics for correct record updates
-    registry[book.identifier] = TPPBookRegistryRecord(
-      book: book,
-      location: record.location,
-      state: record.state,
-      selectionState: selectionState,
-      fulfillmentId: record.fulfillmentId,
-      readiumBookmarks: record.readiumBookmarks,
-      genericBookmarks: record.genericBookmarks
-    )
+  /// Returns the fulfillmentId of a book given its identifier.
+  func fulfillmentId(forIdentifier bookIdentifier: String) -> String? {
+    registry[bookIdentifier]?.fulfillmentId
   }
   
-  /// Updates book metadata (e.g., from OPDS feed) in the registry and returns the updated book.
-  func updatedBookMetadata(_ book: TPPBook) -> TPPBook? {
-    guard let bookRecord = registry[book.identifier] else {
-      return nil
-    }
-    let updatedBook = bookRecord.book.bookWithMetadata(from: book)
-    registry[book.identifier]?.book = updatedBook
-    save()
-    return updatedBook
-  }
-
-  /// Returns the state of a book given its identifier.
-  func state(for bookIdentifier: String) -> TPPBookState {
-    return registry[bookIdentifier]?.state ?? .Unregistered
+  /// Returns whether a book is processing something, given its identifier.
+  func processing(forIdentifier bookIdentifier: String) -> Bool {
+    processingIdentifiers.contains(bookIdentifier)
   }
 
   /// Returns the selection state of a book given its identifier.
   func selectionState(for bookIdentifier: String) -> BookSelectionState {
     return registry[bookIdentifier]?.selectionState ?? .SelectionUnregistered
   }
-
-  /// Sets the state for a book previously registered given its identifier.
-  func setState(_ state: TPPBookState, for bookIdentifier: String) {
-    registry[bookIdentifier]?.state = state
-    save()
-  }
-
-  /// Sets the selection state for a book previously registered given its identifier.
-  func setSelectionState(_ selectionState: BookSelectionState, for bookIdentifier: String) {
-    registry[bookIdentifier]?.selectionState = selectionState
-    save()
-  }
-
-  /// Returns the book for a given identifier if it is registered, else nil.
-  func book(forIdentifier bookIdentifier: String) -> TPPBook? {
-    registry[bookIdentifier]?.book
+  
+  /// Returns the state of a book given its identifier.
+  func state(for bookIdentifier: String) -> TPPBookState {
+    return registry[bookIdentifier]?.state ?? .Unregistered
   }
   
   /// Sets the fulfillmentId for a book previously registered given its identifier.
-  func setFulfillmentId(_ fulfillmentId: String, for bookIdentifier: String) {
+  func setFulfillmentId(
+    _ fulfillmentId: String,
+    for bookIdentifier: String
+  ) {
     registry[bookIdentifier]?.fulfillmentId = fulfillmentId
     save()
-  }
-
-  /// Returns the fulfillmentId of a book given its identifier.
-  func fulfillmentId(forIdentifier bookIdentifier: String) -> String? {
-    registry[bookIdentifier]?.fulfillmentId
   }
   
   /// Sets the processing flag for a book previously registered given its identifier.
@@ -494,68 +618,103 @@ class TPPBookRegistry: NSObject, TPPBookRegistrySyncing {
     } else {
       processingIdentifiers.remove(bookIdentifier)
     }
-    NotificationCenter.default.post(name: .TPPBookProcessingDidChange, object: nil, userInfo: [
-      TPPNotificationKeys.bookProcessingBookIDKey: bookIdentifier,
-      TPPNotificationKeys.bookProcessingValueKey: processing
-    ])
-  }
-  
-  /// Returns whether a book is processing something, given its identifier.
-  func processing(forIdentifier bookIdentifier: String) -> Bool {
-    processingIdentifiers.contains(bookIdentifier)
+    NotificationCenter.default.post(
+      name: .TPPBookProcessingDidChange,
+      object: nil,
+      userInfo: [
+        TPPNotificationKeys.bookProcessingBookIDKey: bookIdentifier,
+        TPPNotificationKeys.bookProcessingValueKey: processing,
+      ])
   }
 
-  
+  /// Sets the selection state for a book previously registered given its identifier.
+  func setSelectionState(
+    _ selectionState: BookSelectionState,
+    for bookIdentifier: String
+  ) {
+    registry[bookIdentifier]?.selectionState = selectionState
+    save()
+  }
+
+  /// Sets the state for a book previously registered given its identifier.
+  func setState(
+    _ state: TPPBookState,
+    for bookIdentifier: String
+  ) {
+    registry[bookIdentifier]?.state = state
+    save()
+  }
+
   // MARK: - Book Cover
-  
+
   /// Immediately returns the cached thumbnail if available, else nil. Generated images are not
   /// returned. The book does not have to be registered in order to retrieve a cover.
   func cachedThumbnailImage(for book: TPPBook) -> UIImage? {
     return coverRegistry.cachedThumbnailImageForBook(book)
   }
   
+  /// Returns cover image if it exists, or falls back to thumbnail image load.
+  func coverImage(
+    for book: TPPBook,
+    handler: @escaping (_ image: UIImage?) -> Void
+  ) {
+    coverRegistry.coverImageForBook(book, handler: handler)
+  }
+
   /// Returns the thumbnail for a book via a handler called on the main thread. The book does not have
   /// to be registered in order to retrieve a cover.
-  func thumbnailImage(for book: TPPBook, handler: @escaping (_ image: UIImage?) -> Void) {
+  func thumbnailImage(
+    for book: TPPBook,
+    handler: @escaping (_ image: UIImage?) -> Void
+  ) {
     coverRegistry.thumbnailImageForBook(book, handler: handler)
   }
 
   /// The dictionary passed to the handler maps book identifiers to images.
   /// The handler is always called on the main thread.
   /// The books do not have to be registered in order to retrieve covers.
-  func thumbnailImages(forBooks books: Set<TPPBook>, handler: @escaping (_ bookIdentifiersToImages: [String: UIImage]) -> Void) {
+  func thumbnailImages(
+    forBooks books: Set<TPPBook>,
+    handler: @escaping (_ bookIdentifiersToImages: [String: UIImage]) -> Void
+  ) {
     coverRegistry.thumbnailImagesForBooks(books, handler: handler)
   }
   
-  /// Returns cover image if it exists, or falls back to thumbnail image load.
-  func coverImage(for book: TPPBook, handler: @escaping (_ image: UIImage?) -> Void) {
-    coverRegistry.coverImageForBook(book, handler: handler)
-  }
 }
 
-// MARK: - TPPBookRegistryProvider
+// MARK: - TPPBookRegistry extension
 
 extension TPPBookRegistry: TPPBookRegistryProvider {
-  
-  /// Sets the location for a book previously registered given its identifier.
-  func setLocation(_ location: TPPBookLocation?, forIdentifier bookIdentifier: String) {
-    registry[bookIdentifier]?.location = location
-    save()
-  }
-  
+
   /// Returns the location of a book given its identifier.
   func location(forIdentifier bookIdentifier: String) -> TPPBookLocation? {
     registry[bookIdentifier]?.location
   }
   
+  /// Sets the location for a book previously registered given its identifier.
+  func setLocation(
+    _ location: TPPBookLocation?,
+    forIdentifier bookIdentifier: String
+  ) {
+    registry[bookIdentifier]?.location = location
+    save()
+  }
+
+  // MARK: - Readium Bookmarks
+  
   /// Returns the bookmarks for a book given its identifier.
-  func readiumBookmarks(forIdentifier bookIdentifier: String) -> [TPPReadiumBookmark] {
+  func readiumBookmarks(forIdentifier bookIdentifier: String)
+    -> [TPPReadiumBookmark]
+  {
     registry[bookIdentifier]?.readiumBookmarks?
       .sorted { $0.progressWithinBook < $1.progressWithinBook } ?? []
   }
 
   /// Adds bookmark for a book given its identifier
-  func add(_ bookmark: TPPReadiumBookmark, forIdentifier bookIdentifier: String) {
+  func add(
+    _ bookmark: TPPReadiumBookmark,
+    forIdentifier bookIdentifier: String
+  ) {
     guard registry[bookIdentifier] != nil else {
       return
     }
@@ -565,83 +724,114 @@ extension TPPBookRegistry: TPPBookRegistryProvider {
     registry[bookIdentifier]?.readiumBookmarks?.append(bookmark)
     save()
   }
-  
+
   /// Deletes bookmark for a book given its identifer.
-  func delete(_ bookmark: TPPReadiumBookmark, forIdentifier bookIdentifier: String) {
+  func delete(
+    _ bookmark: TPPReadiumBookmark,
+    forIdentifier bookIdentifier: String
+  ) {
     registry[bookIdentifier]?.readiumBookmarks?.removeAll { $0 == bookmark }
     save()
   }
-  
+
   /// Replace a bookmark with another, given its identifer.
-  func replace(_ oldBookmark: TPPReadiumBookmark, with newBookmark: TPPReadiumBookmark, forIdentifier bookIdentifier: String) {
+  func replace(
+    _ oldBookmark: TPPReadiumBookmark,
+    with newBookmark: TPPReadiumBookmark,
+    forIdentifier bookIdentifier: String
+  ) {
     registry[bookIdentifier]?.readiumBookmarks?.removeAll { $0 == oldBookmark }
     registry[bookIdentifier]?.readiumBookmarks?.append(newBookmark)
     save()
   }
-  
+
   // MARK: - Generic Bookmarks
-  
+
   /// Returns the generic bookmarks for a any renderer's bookmarks given its identifier
-  func genericBookmarksForIdentifier(_ bookIdentifier: String) -> [TPPBookLocation] {
+  func genericBookmarksForIdentifier(_ bookIdentifier: String)
+    -> [TPPBookLocation]
+  {
     registry[bookIdentifier]?.genericBookmarks ?? []
   }
   
-  func addOrReplaceGenericBookmark(_ location: TPPBookLocation, forIdentifier bookIdentifier: String) {
-    guard let existingBookmark = registry[bookIdentifier]?.genericBookmarks?.first(where: { $0 == location }) else {
-      addGenericBookmark(location, forIdentifier: bookIdentifier)
-      return
-    }
-
-    replaceGenericBookmark(existingBookmark, with: location, forIdentifier: bookIdentifier)
-  }
-  
   /// Adds a generic bookmark (book location) for a book given its identifier
-  func addGenericBookmark(_ location: TPPBookLocation, forIdentifier bookIdentifier: String) {
+  func addGenericBookmark(
+    _ location: TPPBookLocation,
+    forIdentifier bookIdentifier: String
+  ) {
     guard registry[bookIdentifier] != nil else {
       return
     }
-
+    
     if registry[bookIdentifier]?.genericBookmarks == nil {
       registry[bookIdentifier]?.genericBookmarks = [TPPBookLocation]()
     }
     registry[bookIdentifier]?.genericBookmarks?.append(location)
     save()
   }
-  
-   /// Deletes a generic bookmark (book location) for a book given its identifier
-  func deleteGenericBookmark(_ location: TPPBookLocation, forIdentifier bookIdentifier: String) {
-    registry[bookIdentifier]?.genericBookmarks?.removeAll { $0.isSimilarTo(location) }
+
+  func addOrReplaceGenericBookmark(
+    _ location: TPPBookLocation,
+    forIdentifier bookIdentifier: String
+  ) {
+    guard
+      let existingBookmark = registry[bookIdentifier]?.genericBookmarks?.first(
+        where: { $0 == location })
+    else {
+      addGenericBookmark(location, forIdentifier: bookIdentifier)
+      return
+    }
+
+    replaceGenericBookmark(
+      existingBookmark, with: location, forIdentifier: bookIdentifier)
+  }
+
+  /// Deletes a generic bookmark (book location) for a book given its identifier
+  func deleteGenericBookmark(
+    _ location: TPPBookLocation,
+    forIdentifier bookIdentifier: String
+  ) {
+    registry[bookIdentifier]?.genericBookmarks?.removeAll {
+      $0.isSimilarTo(location)
+    }
     save()
   }
-  
-  func replaceGenericBookmark(_ oldLocation: TPPBookLocation, with newLocation: TPPBookLocation, forIdentifier bookIdentifier: String) {
+
+  func replaceGenericBookmark(
+    _ oldLocation: TPPBookLocation,
+    with newLocation: TPPBookLocation,
+    forIdentifier bookIdentifier: String
+  ) {
     deleteGenericBookmark(oldLocation, forIdentifier: bookIdentifier)
     registry[bookIdentifier]?.genericBookmarks?.append(newLocation)
     save()
   }
 }
 
+// MARK: - TPPBookLocation extension
+
 extension TPPBookLocation {
-  
+
   func locationStringDictionary() -> [String: Any]? {
     guard let data = locationString.data(using: .utf8),
-            let dictionary = try? JSONSerialization.jsonObject(with: data, options: .allowFragments) as? [String: Any]
+      let dictionary = try? JSONSerialization.jsonObject(
+        with: data, options: .allowFragments) as? [String: Any]
     else { return nil }
-    
+
     return dictionary
   }
 
   func isSimilarTo(_ location: TPPBookLocation) -> Bool {
     guard renderer == location.renderer,
-          let locationDict = locationStringDictionary(),
-          let otherLocationDict = location.locationStringDictionary()
+      let locationDict = locationStringDictionary(),
+      let otherLocationDict = location.locationStringDictionary()
     else { return false }
-            
+
     var areEqual = true
-    
+
     for (key, value) in locationDict {
       if key == "lastSavedTimeStamp" { continue }
-      
+
       if let otherValue = otherLocationDict[key] {
         if "\(value)" != "\(otherValue)" {
           areEqual = false
@@ -652,7 +842,7 @@ extension TPPBookLocation {
         break
       }
     }
-    
+
     return areEqual
   }
 }

--- a/Palace/Book/Models/TPPBookRegistryRecord.swift
+++ b/Palace/Book/Models/TPPBookRegistryRecord.swift
@@ -39,6 +39,7 @@ class TPPBookRegistryRecord: NSObject {
     super.init()
 
     var actuallyOnHold = false
+    let isSelectedBook = selectionState == .Selected
 
     if let defaultAcquisition = book.defaultAcquisition {
       defaultAcquisition.availability.matchUnavailable { _ in
@@ -66,7 +67,7 @@ class TPPBookRegistryRecord: NSObject {
       self.state = .Unsupported
     }
 
-    if !actuallyOnHold {
+    if !actuallyOnHold && !isSelectedBook {
       if self.state == .Holding || self.state == .Unsupported {
         // Since we're not in some download-related state and we're not unregistered,
         // we must need to be downloaded.

--- a/Palace/MyBooks/Downloading/MyBooksDownloadCenter.swift
+++ b/Palace/MyBooks/Downloading/MyBooksDownloadCenter.swift
@@ -72,6 +72,7 @@ import OverdriveProcessor
           borrowedBook,
           location: location,
           state: .DownloadNeeded,
+          selectionState: .Selected, // just placeholder code
           fulfillmentId: nil,
           readiumBookmarks: nil,
           genericBookmarks: nil
@@ -180,7 +181,15 @@ import OverdriveProcessor
   
   private func processUnregisteredState(for book: TPPBook, location: TPPBookLocation?, loginRequired: Bool?) -> TPPBookState {
     if book.defaultAcquisitionIfBorrow == nil && (book.defaultAcquisitionIfOpenAccess != nil || !(loginRequired ?? false)) {
-      bookRegistry.addBook(book, location: location, state: .DownloadNeeded, fulfillmentId: nil, readiumBookmarks: nil, genericBookmarks: nil)
+      bookRegistry.addBook(
+        book,
+        location: location,
+        state: .DownloadNeeded,
+        selectionState: .Selected, //just placeholder code
+        fulfillmentId: nil,
+        readiumBookmarks: nil,
+        genericBookmarks: nil
+      )
       return .DownloadNeeded
     }
     return .Unregistered
@@ -919,6 +928,7 @@ extension MyBooksDownloadCenter: URLSessionTaskDelegate {
     bookRegistry.addBook(book,
                          location: bookRegistry.location(forIdentifier: book.identifier),
                          state: .Downloading,
+                         selectionState: .Selected, // just placeholder codd
                          fulfillmentId: nil,
                          readiumBookmarks: nil,
                          genericBookmarks: nil)
@@ -1014,6 +1024,7 @@ extension MyBooksDownloadCenter {
     bookRegistry.addBook(book,
                                    location: location,
                                    state: .DownloadFailed,
+                                   selectionState: .Selected, // just placeholder code
                                    fulfillmentId: nil,
                                    readiumBookmarks: nil,
                                    genericBookmarks: nil)

--- a/Palace/OPDS/TPPOPDSEntry.h
+++ b/Palace/OPDS/TPPOPDSEntry.h
@@ -24,6 +24,7 @@
 @property (nonatomic, readonly) NSString *providerName; // nilable
 @property (nonatomic, readonly) NSDate *published; // nilable
 @property (nonatomic, readonly) NSString *publisher; // nilable
+@property (nonatomic, readonly) NSDate *selected; // nilable
 @property (nonatomic, readonly) NSString *summary; // nilable
 @property (nonatomic, readonly) NSString *title;
 @property (nonatomic, readonly) NSDate *updated;

--- a/Palace/OPDS/TPPOPDSEntry.m
+++ b/Palace/OPDS/TPPOPDSEntry.m
@@ -27,6 +27,7 @@
 @property (nonatomic) NSString *providerName;
 @property (nonatomic) NSDate *published;
 @property (nonatomic) NSString *publisher;
+@property (nonatomic) NSDate *selected;
 @property (nonatomic) NSString *summary;
 @property (nonatomic) NSString *title;
 @property (nonatomic) NSDate *updated;
@@ -185,6 +186,18 @@
   }
   
   self.publisher = [entryXML firstChildWithName:@"publisher"].value;
+  
+  {
+    NSString *const selectedString = [entryXML firstChildWithName:@"selected"].value;
+    
+    if(selectedString) {
+      self.selected = [NSDate dateWithRFC3339String:selectedString];
+      TPPLOG_F(@"Entry contains optional 'selected' element: %@", self.selected);
+    } else {
+      self.selected = nil;
+      TPPLOG(@"Entry does not contain optional 'selected' element.");
+    }
+  }
   
   self.summary = [entryXML firstChildWithName:@"summary"].value;
   


### PR DESCRIPTION
## Major changes and updates in this subtask

### Favorite view lists all user's favorite books
- The _selected feed_ is used for showing user's favorite audiobooks and e-books in the app's favorite tab
  - this new OPDS acquisition feed contains all the books patron has selected (as favorite)
  - see more details of the feed here: https://github.com/NatLibFi/ekirjasto-circulation/pull/121
- The basic structure of the favorite books list is otherwise identical to the list of borrowed books and the list of reserved books, for example
  - user can sort favorite book list by author name or book title
  - user can search from favorite books list
 
### New book record state was added: the book selection state
- bookRegistryRecord's **selectionState** must be one of these
   - selected
   - unselected
   - selectionUnregistered
- new book records are initialized with book selection state
- the selection statie is separate from the state used to map loans and holds state (**state**)  

### The sync function synchronises now the user's loans, holds, and selected books
- The updated **sync** function in book registry first synchronises the user's loans and holds, and then the user's selected books.
- NB syncLoandAndHolds and syncSelected functions need to be refactored in more detail later 

