### PR TITLE
EKIRJASTO-284 Button for favorite action

### DIFF
--- a/Palace.xcodeproj/project.pbxproj
+++ b/Palace.xcodeproj/project.pbxproj
@@ -1032,6 +1032,12 @@
 		7530C8D12D80CF700024E184 /* FavoritesMainView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7530C8D02D80CF660024E184 /* FavoritesMainView.swift */; };
 		7530C8D22D80CF700024E184 /* FavoritesMainView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7530C8D02D80CF660024E184 /* FavoritesMainView.swift */; };
 		7530C8D32D80CF700024E184 /* FavoritesMainView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7530C8D02D80CF660024E184 /* FavoritesMainView.swift */; };
+		7582FFD02DB9188A0057AC71 /* BookSelectionButtonsView.m in Sources */ = {isa = PBXBuildFile; fileRef = 7582FFCF2DB918880057AC71 /* BookSelectionButtonsView.m */; };
+		7582FFD12DB9188A0057AC71 /* BookSelectionButtonsView.m in Sources */ = {isa = PBXBuildFile; fileRef = 7582FFCF2DB918880057AC71 /* BookSelectionButtonsView.m */; };
+		7582FFD22DB9188A0057AC71 /* BookSelectionButtonsView.m in Sources */ = {isa = PBXBuildFile; fileRef = 7582FFCF2DB918880057AC71 /* BookSelectionButtonsView.m */; };
+		7582FFD52DBAE1FB0057AC71 /* BookSelectionButtonsState.m in Sources */ = {isa = PBXBuildFile; fileRef = 7582FFD42DBAE1F00057AC71 /* BookSelectionButtonsState.m */; };
+		7582FFD62DBAE1FB0057AC71 /* BookSelectionButtonsState.m in Sources */ = {isa = PBXBuildFile; fileRef = 7582FFD42DBAE1F00057AC71 /* BookSelectionButtonsState.m */; };
+		7582FFD72DBAE1FB0057AC71 /* BookSelectionButtonsState.m in Sources */ = {isa = PBXBuildFile; fileRef = 7582FFD42DBAE1F00057AC71 /* BookSelectionButtonsState.m */; };
 		75E833DA2D73B49400D2B840 /* LoansAndHoldsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 75E833D92D73B48D00D2B840 /* LoansAndHoldsView.swift */; };
 		75E833DB2D73B49400D2B840 /* LoansAndHoldsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 75E833D92D73B48D00D2B840 /* LoansAndHoldsView.swift */; };
 		75E833DC2D73B49400D2B840 /* LoansAndHoldsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 75E833D92D73B48D00D2B840 /* LoansAndHoldsView.swift */; };
@@ -1972,6 +1978,10 @@
 		7530C8C22D80C80B0024E184 /* FavoritesMainViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FavoritesMainViewController.swift; sourceTree = "<group>"; };
 		7530C8C62D80CA6E0024E184 /* FavoritesViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FavoritesViewModel.swift; sourceTree = "<group>"; };
 		7530C8D02D80CF660024E184 /* FavoritesMainView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FavoritesMainView.swift; sourceTree = "<group>"; };
+		7582FFCE2DB918630057AC71 /* BookSelectionButtonsView.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = BookSelectionButtonsView.h; sourceTree = "<group>"; };
+		7582FFCF2DB918880057AC71 /* BookSelectionButtonsView.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = BookSelectionButtonsView.m; sourceTree = "<group>"; };
+		7582FFD32DBADF240057AC71 /* BookSelectionButtonsState.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = BookSelectionButtonsState.h; sourceTree = "<group>"; };
+		7582FFD42DBAE1F00057AC71 /* BookSelectionButtonsState.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = BookSelectionButtonsState.m; sourceTree = "<group>"; };
 		75E833D92D73B48D00D2B840 /* LoansAndHoldsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoansAndHoldsView.swift; sourceTree = "<group>"; };
 		75E833E12D73B4B900D2B840 /* LoansAndHoldsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoansAndHoldsViewController.swift; sourceTree = "<group>"; };
 		75E834132D76088600D2B840 /* HoldsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HoldsView.swift; sourceTree = "<group>"; };
@@ -3313,6 +3323,10 @@
 		75EA321C2DA98B7500FD3AC2 /* BookButtons */ = {
 			isa = PBXGroup;
 			children = (
+				7582FFD32DBADF240057AC71 /* BookSelectionButtonsState.h */,
+				7582FFD42DBAE1F00057AC71 /* BookSelectionButtonsState.m */,
+				7582FFCE2DB918630057AC71 /* BookSelectionButtonsView.h */,
+				7582FFCF2DB918880057AC71 /* BookSelectionButtonsView.m */,
 				73B5DFDB26052A1800225C12 /* TPPBookButtonsState.h */,
 				73B5DFDA26052A1800225C12 /* TPPBookButtonsState.m */,
 				E66A6C421EAFB63300AA282D /* TPPBookButtonsView.h */,
@@ -4892,6 +4906,7 @@
 				331263752A287F53006BA87D /* TPPEncryptedPDFPageViewController.swift in Sources */,
 				363C620C2B14F08C00858AA5 /* UserProfileDocument+Links.swift in Sources */,
 				331263762A287F53006BA87D /* AdobeDRMContentProtection.swift in Sources */,
+				7582FFD02DB9188A0057AC71 /* BookSelectionButtonsView.m in Sources */,
 				331263772A287F53006BA87D /* TPPBookLocation.swift in Sources */,
 				331263782A287F53006BA87D /* TPPEncryptedPDFDataProvider.m in Sources */,
 				331263792A287F53006BA87D /* TPPNetworkExecutor.swift in Sources */,
@@ -4904,6 +4919,7 @@
 				3312637F2A287F53006BA87D /* NSError+NYPLAdditions.swift in Sources */,
 				331263802A287F53006BA87D /* TPPReachability.m in Sources */,
 				750732EF2D887261005B2254 /* BookSelectionState.swift in Sources */,
+				7582FFD62DBAE1FB0057AC71 /* BookSelectionButtonsState.m in Sources */,
 				331263812A287F53006BA87D /* TPPCatalogLaneCell.m in Sources */,
 				336F0D582A432860009E37F6 /* EkirjastoRoundedLabel.swift in Sources */,
 				331263822A287F53006BA87D /* URLResponse+NYPL.swift in Sources */,
@@ -5301,6 +5317,7 @@
 				36A07DBE2BB5B6FD00583E0B /* PasskeyView.swift in Sources */,
 				21E41788292810F600A78606 /* TPPPDFThumbnailView.swift in Sources */,
 				E795A76E2A74074300314EC8 /* DataManager.swift in Sources */,
+				7582FFD52DBAE1FB0057AC71 /* BookSelectionButtonsState.m in Sources */,
 				73EB0AD225821DF4006BC997 /* TPPBookCellDelegate.m in Sources */,
 				E733E4AE2AFD792100D5052A /* UserProfileDocument+Links.swift in Sources */,
 				E5EFDE79298C43DD00258CA3 /* BookButtonState.swift in Sources */,
@@ -5423,6 +5440,7 @@
 				73EB0B1E25821DF4006BC997 /* TPPAccountSignInViewController.m in Sources */,
 				73EB0B1F25821DF4006BC997 /* UserProfileDocument.swift in Sources */,
 				21E41777292810E000A78606 /* TPPPDFDocumentMetadata.swift in Sources */,
+				7582FFD12DB9188A0057AC71 /* BookSelectionButtonsView.m in Sources */,
 				E76AD92C296DCB76008ECC61 /* NotificationService.swift in Sources */,
 				73EB0B2025821DF4006BC997 /* AccountsManager.swift in Sources */,
 				217595DE27B680D400BA0FDD /* TPPReaderSettingsVC.swift in Sources */,
@@ -5498,6 +5516,7 @@
 				739062D225358CF900D0743D /* TPPSignInBusinessLogicUIDelegate.swift in Sources */,
 				E57E798429D4D407006D0F87 /* String+Extensions.swift in Sources */,
 				E7376EC0287DE9C00095AADF /* CGSize.swift in Sources */,
+				7582FFD72DBAE1FB0057AC71 /* BookSelectionButtonsState.m in Sources */,
 				1120749319D20BF9008203A4 /* TPPBookCellCollectionViewController.m in Sources */,
 				0857A0FF247835FF00C7984E /* TPPKeychainStoredVariable.swift in Sources */,
 				750732F12D887261005B2254 /* BookSelectionState.swift in Sources */,
@@ -5741,6 +5760,7 @@
 				2126FE2E25C059250095C45C /* ReaderError.swift in Sources */,
 				21562CC3276BB52700C03372 /* AdobeDRMAlerts.swift in Sources */,
 				5D7CF8B922C3FC06007CAA34 /* TPPErrorLogger.swift in Sources */,
+				7582FFD22DB9188A0057AC71 /* BookSelectionButtonsView.m in Sources */,
 				E7A9909027EE4EF400D9486F /* LicensesService.swift in Sources */,
 				E5FFB96728AED70E0042907F /* ActivityIndicator.swift in Sources */,
 				E7FD4E52286CCF2C00D26A3B /* TPPPDFLocation.swift in Sources */,

--- a/Palace/Book/UI/BookButtons/BookSelectionButtonsState.h
+++ b/Palace/Book/UI/BookButtons/BookSelectionButtonsState.h
@@ -1,0 +1,15 @@
+//
+//  BookSelectionButtonsState.h
+//
+
+@import Foundation;
+
+typedef NS_ENUM(NSInteger, BookSelectionButtonsState) {
+  BookSelectionButtonsStateCanSelect,
+  BookSelectionButtonsStateCanUnselect
+};
+
+@class TPPBook;
+
+BookSelectionButtonsState
+BookSelectionButtonsViewStateWithBook(TPPBook* book);

--- a/Palace/Book/UI/BookButtons/BookSelectionButtonsState.m
+++ b/Palace/Book/UI/BookButtons/BookSelectionButtonsState.m
@@ -1,0 +1,29 @@
+//
+//  BookSelectionButtonsState.m
+//
+
+#import "BookSelectionButtonsState.h"
+#import "Palace-Swift.h"
+
+BookSelectionButtonsState
+BookSelectionButtonsViewStateWithBook(TPPBook* book)
+{
+
+  __block BookSelectionButtonsState bookSelectionButtonsState = BookSelectionButtonsStateCanSelect;
+
+  BookSelectionState bookSelectionState = [[TPPBookRegistry shared] selectionStateFor:book.identifier];
+
+  switch(bookSelectionState) {
+    case BookSelectionStateSelected:
+      bookSelectionButtonsState = BookSelectionButtonsStateCanUnselect;
+      break;
+    case BookSelectionStateUnselected:
+      bookSelectionButtonsState = BookSelectionButtonsStateCanSelect;
+      break;
+    case BookSelectionStateSelectionUnregistered:
+      bookSelectionButtonsState = BookSelectionButtonsStateCanSelect;
+      break;
+  }
+
+  return bookSelectionButtonsState;
+}

--- a/Palace/Book/UI/BookButtons/BookSelectionButtonsView.h
+++ b/Palace/Book/UI/BookButtons/BookSelectionButtonsView.h
@@ -1,0 +1,28 @@
+//
+//  BookSelectionButtonsView.h
+//
+
+#import "BookSelectionButtonsState.h"
+#import "TPPBookButtonsView.h"
+#import <UIKit/UIKit.h>
+
+@class TPPBook;
+
+@protocol BookSelectionButtonsDelegate;
+
+@interface BookSelectionButtonsView : UIView
+
+@property (nonatomic, weak) TPPBook *book;
+@property (nonatomic, weak) id<TPPBookButtonsDelegate> delegate;
+@property (nonatomic) BookSelectionButtonsState selectionState;
+
+- (instancetype _Nonnull )initWithBook:(TPPBook *_Nonnull)book delegate:(id<TPPBookButtonsDelegate>_Nonnull)delegate;
+
+@end
+
+@protocol BookSelectionButtonsDelegate <NSObject>
+
+- (void)didSelectSelectForBook:(TPPBook *_Nonnull)book completion:(void (^ _Nullable)(void))completion;
+- (void)didSelectUnselectForBook:(TPPBook * _Nonnull)book completion:(void (^ _Nullable)(void))completion;
+
+@end

--- a/Palace/Book/UI/BookButtons/BookSelectionButtonsView.m
+++ b/Palace/Book/UI/BookButtons/BookSelectionButtonsView.m
@@ -1,0 +1,190 @@
+//
+//  BookSelectionButtonsView.m
+//
+
+#import "BookSelectionButtonsView.h"
+#import "Palace-Swift.h"
+@import PureLayout;
+
+@interface BookSelectionButtonsView ()
+
+@property (nonatomic) UIButton *selectButton;
+@property (nonatomic) UIButton *unselectButton;
+@property (nonatomic) NSMutableArray *constraints;
+@property (nonatomic) NSMutableArray *observers;
+@property (nonatomic) NSMutableArray *visibleButtons;
+
+@end
+
+@implementation BookSelectionButtonsView
+
+- (instancetype)initWithBook:(TPPBook *)book delegate:(id<TPPBookButtonsDelegate>)delegate {
+
+  self = [super init];
+
+  if (self) {
+    _book = book;
+    _delegate = delegate;
+
+    self.constraints = [[NSMutableArray alloc] init];
+
+    [self setupButtons];
+
+    [self.observers addObject:[
+      [NSNotificationCenter defaultCenter]
+        addObserverForName:NSNotification.TPPBookProcessingDidChange
+        object:nil
+        queue:[NSOperationQueue mainQueue]
+        usingBlock:^(NSNotification *note) {
+          if ([note.userInfo[TPPNotificationKeys.bookProcessingBookIDKey] isEqualToString:self.book.identifier]) {
+            BOOL isProcessing = [note.userInfo[TPPNotificationKeys.bookProcessingValueKey] boolValue];
+            [self updateProcessingState:isProcessing];
+          }
+        }
+    ]];
+
+    [self.observers addObject:[
+      [NSNotificationCenter defaultCenter]
+        addObserverForName:NSNotification.TPPReachabilityChanged
+        object:nil
+        queue:[NSOperationQueue mainQueue]
+        usingBlock:^(NSNotification * _Nonnull note) {
+          #pragma unused(note)
+          [self updateButtons];
+        }
+    ]];
+
+    [self updateButtons];
+  }
+
+  return self;
+}
+
+- (void)dealloc {
+
+  for(id const observer in self.observers) {
+    [[NSNotificationCenter defaultCenter] removeObserver:observer];
+  }
+
+  [self.observers removeAllObjects];
+}
+
+- (void)setupButtons {
+  self.selectButton = [[UIButton alloc] init];
+  self.unselectButton = [[UIButton alloc] init];
+
+  UIImage *selectBookImage = [ImageProvidersMyBooksViewObjcClass selectionIconPlus];
+  UIImage *unselectBookImage = [ImageProvidersMyBooksViewObjcClass selectionIconCheck];
+
+  [self.selectButton
+   setImage:selectBookImage
+   forState:UIControlStateNormal
+  ];
+
+  [self.unselectButton
+   setImage:unselectBookImage
+   forState:UIControlStateNormal
+  ];
+
+  [self.selectButton
+   addTarget:self
+   action:@selector(didSelectSelect)
+   forControlEvents:UIControlEventTouchUpInside
+  ];
+
+  [self.unselectButton
+   addTarget:self
+   action:@selector(didSelectUnselect)
+   forControlEvents:UIControlEventTouchUpInside
+  ];
+
+  [self addSubview:self.selectButton];
+  [self addSubview:self.unselectButton];
+}
+
+- (void)didSelectSelect {
+  [self updateProcessingState:YES];
+  [self.delegate didSelectSelectForBook:self.book completion:nil];
+}
+
+- (void)didSelectUnselect {
+  [self updateProcessingState:YES];
+  [self.delegate didSelectUnselectForBook:self.book completion:nil];
+}
+
+- (void)updateButtons {
+
+  [self.visibleButtons removeAllObjects];
+  [self updateProcessingState:NO];
+  NSMutableArray *visibleButtons = [NSMutableArray array];
+  [UIView setAnimationsEnabled:NO];
+  self.selectButton.hidden = YES;
+  self.unselectButton.hidden = YES;
+
+  switch (self.selectionState) {
+    case BookSelectionButtonsStateCanSelect:
+      TPPLOG(@"Book selection state is Unregistered or Unselected");
+      self.selectButton.hidden = NO;
+      [self.selectButton setTitle:NSLocalizedString(@"Select", nil) forState:UIControlStateNormal];
+      [self.selectButton layoutIfNeeded];
+      [visibleButtons addObject:self.selectButton];
+      break;
+    case BookSelectionButtonsStateCanUnselect:
+      TPPLOG(@"Book selection state is Selected");
+      self.unselectButton.hidden = NO;
+      [self.unselectButton setTitle:NSLocalizedString(@"Unselect", nil) forState:UIControlStateNormal];
+      [self.unselectButton layoutIfNeeded];
+      [visibleButtons addObject:self.unselectButton];
+      break;
+  }
+
+  [UIView setAnimationsEnabled:YES];
+  self.visibleButtons = visibleButtons;
+  [self updateButtonFrames];
+
+}
+
+- (void)updateProcessingState:(BOOL)isCurrentlyProcessing {
+
+  for (UIButton *button in @[self.selectButton, self.unselectButton]) {
+    button.enabled = !isCurrentlyProcessing;
+  }
+
+}
+
+- (void)updateButtonFrames {
+  [NSLayoutConstraint deactivateConstraints:self.constraints];
+
+  if (self.visibleButtons.count == 0) {
+    return;
+  }
+
+  [self.constraints removeAllObjects];
+
+  for (UIButton *button in self.visibleButtons) {
+    [self.constraints addObject:[button autoPinEdgeToSuperviewEdge:ALEdgeTop]];
+    [self.constraints addObject:[button autoPinEdgeToSuperviewEdge:ALEdgeBottom]];
+    [self.constraints addObject:[button autoPinEdgeToSuperviewEdge:ALEdgeLeading]];
+    [self.constraints addObject:[button autoSetDimension:ALDimensionWidth toSize: 15.0 relation:NSLayoutRelationGreaterThanOrEqual ]];
+    [self.constraints addObject:[button autoPinEdgeToSuperviewEdge:ALEdgeTrailing]];
+  }
+
+  //[NSLayoutConstraint activateConstraints:self.constraints];
+  [self setNeedsLayout];
+}
+
+- (void)setBook:(TPPBook *)book {
+  _book = book;
+  [self updateButtons];
+  BOOL isCurrentlyProcessing = [[TPPBookRegistry shared] processingForIdentifier:self.book.identifier];
+  [self updateProcessingState:isCurrentlyProcessing];
+}
+
+- (void)setSelectionState:(BookSelectionButtonsState const)selectionState {
+  _selectionState = selectionState;
+  [self updateButtons];
+  BOOL isCurrentlyProcessing = [[TPPBookRegistry shared] processingForIdentifier:self.book.identifier];
+  [self updateProcessingState:isCurrentlyProcessing];
+}
+
+@end

--- a/Palace/Book/UI/BookButtons/TPPBookButtonsView.h
+++ b/Palace/Book/UI/BookButtons/TPPBookButtonsView.h
@@ -10,6 +10,8 @@
 - (void)didSelectDownloadForBook:(TPPBook *_Null_unspecified)book;
 - (void)didSelectReadForBook:(TPPBook *_Null_unspecified)book;
 - (void)didSelectPlaySample:(TPPBook *_Null_unspecified)book;
+- (void)didSelectSelectForBook:(TPPBook *_Null_unspecified)book completion:(void (^ _Nullable)(void))completion;
+- (void)didSelectUnselectForBook:(TPPBook *_Null_unspecified)book completion:(void (^ _Nullable)(void))completion;
 
 @end
 

--- a/Palace/Book/UI/BookCell/TPPBookCell.m
+++ b/Palace/Book/UI/BookCell/TPPBookCell.m
@@ -57,7 +57,7 @@ TPPBookCell *TPPBookCellDequeue(UICollectionView *const collectionView,
       cell.book = book;
       cell.delegate = [TPPBookCellDelegate sharedDelegate];
       cell.state = TPPBookButtonsViewStateWithAvailability(book.defaultAcquisition.availability);
-
+      cell.selectionState = BookSelectionButtonsViewStateWithBook(book);
       return cell;
     }
     case TPPBookStateDownloadNeeded:
@@ -68,6 +68,7 @@ TPPBookCell *TPPBookCellDequeue(UICollectionView *const collectionView,
       cell.book = book;
       cell.delegate = [TPPBookCellDelegate sharedDelegate];
       cell.state = TPPBookButtonsStateDownloadNeeded;
+      cell.selectionState = BookSelectionButtonsViewStateWithBook(book);
       return cell;
     }
     case TPPBookStateDownloadSuccessful:
@@ -78,6 +79,7 @@ TPPBookCell *TPPBookCellDequeue(UICollectionView *const collectionView,
       cell.book = book;
       cell.delegate = [TPPBookCellDelegate sharedDelegate];
       cell.state = TPPBookButtonsStateDownloadSuccessful;
+      cell.selectionState = BookSelectionButtonsViewStateWithBook(book);
       return cell;
     }
     // SAML started is part of download process, in this step app does authenticate user but didn't begin file downloading yet
@@ -112,7 +114,7 @@ TPPBookCell *TPPBookCellDequeue(UICollectionView *const collectionView,
       cell.book = book;
       cell.delegate = [TPPBookCellDelegate sharedDelegate];
       cell.state = TPPBookButtonsViewStateWithAvailability(book.defaultAcquisition.availability);
-
+      cell.selectionState = BookSelectionButtonsViewStateWithBook(book);
       return cell;
     }
     case TPPBookStateUsed:
@@ -123,6 +125,7 @@ TPPBookCell *TPPBookCellDequeue(UICollectionView *const collectionView,
       cell.book = book;
       cell.delegate = [TPPBookCellDelegate sharedDelegate];
       cell.state = TPPBookButtonsStateUsed;
+      cell.selectionState = BookSelectionButtonsViewStateWithBook(book);
       return cell;
     }
     case TPPBookStateUnsupported: {
@@ -132,6 +135,7 @@ TPPBookCell *TPPBookCellDequeue(UICollectionView *const collectionView,
       cell.book = book;
       cell.delegate = [TPPBookCellDelegate sharedDelegate];
       cell.state = TPPBookButtonsStateUnsupported;
+      cell.selectionState = BookSelectionButtonsViewStateWithBook(book);
       return cell;
     }
   }

--- a/Palace/Book/UI/BookCell/TPPBookCellDelegate.m
+++ b/Palace/Book/UI/BookCell/TPPBookCellDelegate.m
@@ -117,6 +117,18 @@ static const int kServerUpdateDelay = 15;
 #endif
 }
 
+- (void)didSelectSelectForBook:(TPPBook *)book
+                    completion:(void (^ __nullable)(void))completion
+{
+  TPPLOG(@"Did select select for book.");
+}
+
+- (void)didSelectUnselectForBook:(TPPBook *)book
+                      completion:(void (^ __nullable)(void))completion
+{
+  TPPLOG(@"Did select unselect for book.");
+}
+
 - (void)openBook:(TPPBook *)book
 {
   [TPPCirculationAnalytics postEvent:@"open_book" withBook:book];

--- a/Palace/Book/UI/BookCell/TPPBookNormalCell.h
+++ b/Palace/Book/UI/BookCell/TPPBookNormalCell.h
@@ -1,5 +1,6 @@
 #import "TPPBookCell.h"
 #import "TPPBookButtonsState.h"
+#import "BookSelectionButtonsState.h"
 #import "Palace-Swift.h"
 
 @class TPPBookNormalCell;
@@ -11,8 +12,8 @@
 
 @property (nonatomic) TPPBook *book;
 @property (nonatomic) TPPBookButtonsState state;
+@property (nonatomic) BookSelectionButtonsState selectionState;
 @property (nonatomic, weak) id<TPPBookButtonsDelegate> delegate;
-
 @property (nonatomic) UIImageView *cover;
 
 @end

--- a/Palace/Book/UI/BookCell/TPPBookNormalCell.m
+++ b/Palace/Book/UI/BookCell/TPPBookNormalCell.m
@@ -161,6 +161,7 @@
     [self.selectionButtonsView autoPinEdge:ALEdgeRight toEdge:ALEdgeRight ofView:self.contentView withOffset:-15];
     [self.selectionButtonsView layoutIfNeeded];
   }
+  self.selectionButtonsView.book = book;
 
   if(!self.unreadImageView) {
     self.unreadImageView = [[UIImageView alloc] initWithImage:[UIImage imageNamed:@"Unread"]];

--- a/Palace/Book/UI/BookDetailView/TPPBookDetailView.h
+++ b/Palace/Book/UI/BookDetailView/TPPBookDetailView.h
@@ -5,6 +5,7 @@
 @class TPPCatalogLane;
 @class TPPBookDetailTableView;
 typedef NS_ENUM(NSInteger, TPPBookState);
+typedef NS_ENUM(NSInteger, BookSelectionState);
 @protocol TPPCatalogLaneCellDelegate;
 
 @protocol TPPBookDetailViewDelegate
@@ -26,6 +27,7 @@ static CGFloat const SummaryTextAbbreviatedHeight = 150.0;
 @property (nonatomic) double downloadProgress;
 @property (nonatomic) BOOL downloadStarted;
 @property (nonatomic) TPPBookState state;
+@property (nonatomic) BookSelectionState selectionState;
 @property (nonatomic) TPPBookDetailTableViewDelegate *tableViewDelegate;
 @property (nonatomic, readonly) UIButton *readMoreLabel;
 @property (nonatomic, readonly) UITextView *summaryTextView;

--- a/Palace/Book/UI/BookDetailView/TPPBookDetailView.m
+++ b/Palace/Book/UI/BookDetailView/TPPBookDetailView.m
@@ -1,7 +1,7 @@
 #import "TPPAttributedString.h"
-
 #import "TPPBookCellDelegate.h"
 #import "TPPBookButtonsView.h"
+#import "BookSelectionButtonsView.h"
 #import "TPPBookDetailDownloadFailedView.h"
 #import "TPPBookDetailDownloadingView.h"
 #import "TPPBookDetailNormalView.h"
@@ -17,7 +17,6 @@
 #import "TPPOPDSFeed.h"
 #import "Palace-Swift.h"
 #import "UIFont+TPPSystemFontOverride.h"
-
 #import <PureLayout/PureLayout.h>
 
 @interface TPPBookDetailView () <TPPBookDownloadCancellationDelegate, TPPBookButtonsSampleDelegate, BookDetailTableViewDelegate>
@@ -40,6 +39,7 @@
 @property (nonatomic) UIButton *closeButton;
 
 @property (nonatomic) TPPBookButtonsView *buttonsView;
+@property (nonatomic) BookSelectionButtonsView *selectionButtonsView;
 @property (nonatomic) TPPBookDetailDownloadFailedView *downloadFailedView;
 @property (nonatomic) TPPBookDetailDownloadingView *downloadingView;
 @property (nonatomic) TPPBookDetailNormalView *normalView;
@@ -87,6 +87,7 @@ static CGFloat const CoverImageMaxWidth = 130;
 static CGFloat const TabBarHeight = 80.0;
 static CGFloat const SampleToolbarHeight = 80.0;
 static CGFloat const TitleLabelMinimumWidth = 185.0;
+static CGFloat const SelectionButtonMinimumWidth = 25.0;
 static CGFloat const NormalViewMinimumHeight = 38.0;
 static CGFloat const VerticalPadding = 20.0;
 static CGFloat const MainTextPaddingLeft = 30.0;
@@ -115,9 +116,9 @@ static NSString *DetailHTMLTemplate = nil;
   
   self.containerView = [[UIView alloc] init];
 
-  
   [self createHeaderLabels];
   [self createButtonsView];
+  [self createSelectionButtonsView];
   [self createBookDescriptionViews];
   [self createFooterLabels];
   [self createDownloadViews];
@@ -140,10 +141,10 @@ static NSString *DetailHTMLTemplate = nil;
   [self.containerView addSubview:self.bookFormatLabel];
   [self.containerView addSubview:self.authorsLabel];
   [self.containerView addSubview:self.buttonsView];
+  [self.containerView addSubview:self.selectionButtonsView];
   [self.containerView addSubview:self.summarySectionLabel];
   [self.containerView addSubview:self.summaryTextView];
   [self.containerView addSubview:self.readMoreLabel];
-  
   [self.containerView addSubview:self.topFootnoteSeparater];
   [self.containerView addSubview:self.infoSectionLabel];
   [self.containerView addSubview:self.publishedLabelKey];
@@ -222,6 +223,15 @@ static NSString *DetailHTMLTemplate = nil;
   self.buttonsView.book = self.book;
 }
 
+- (void)createSelectionButtonsView
+{
+  self.selectionButtonsView = [[BookSelectionButtonsView alloc]
+                               initWithBook:self.book
+                               delegate:[TPPBookCellDelegate sharedDelegate]
+  ];
+  self.selectionButtonsView.translatesAutoresizingMaskIntoConstraints = NO;
+}
+
 - (void)createBookDescriptionViews
 {
   self.summarySectionLabel = [[EkirjastoRoundedLabel alloc] init]; //Edited by Ellibs
@@ -278,7 +288,6 @@ static NSString *DetailHTMLTemplate = nil;
   self.readMoreLabel.titleEdgeInsets = UIEdgeInsetsMake(0, 0, 0, 10); //Added by Ellibs
   [self.readMoreLabel setTitleColor:[TPPConfiguration compatiblePrimaryColor] forState:UIControlStateNormal]; //Added by Ellibs
   [self.readMoreLabel addTarget:self action:@selector(readMoreTapped:) forControlEvents:UIControlEventTouchUpInside];
-  
   [self.readMoreLabel setContentHorizontalAlignment:UIControlContentHorizontalAlignmentRight];
   [self.readMoreLabel setTitle:NSLocalizedString(@"Read more", nil) forState:UIControlStateNormal]; //Edited by Ellibs
   [self.readMoreLabel setTitleColor:[TPPConfiguration mainColor] forState:UIControlStateNormal];
@@ -307,14 +316,13 @@ static NSString *DetailHTMLTemplate = nil;
     self.blurCoverImageView.image = image;
   }];
 
-  
   self.contentTypeBadge = [[TPPContentBadgeImageView alloc] initWithBadgeImage:TPPBadgeImageAudiobook];
   self.contentTypeBadge.hidden = YES;
 
   if ([self.book defaultBookContentType] == TPPBookContentTypeAudiobook) {
     self.contentTypeBadge.hidden = NO;
   }
-  
+
   self.bookFormatLabel = [[UILabel alloc] init];
   self.bookFormatLabel.text = self.book.generalBookFormat;
 
@@ -326,10 +334,10 @@ static NSString *DetailHTMLTemplate = nil;
   self.subtitleLabel.attributedText = TPPAttributedStringForSubtitleFromString(self.book.subtitle);
   self.subtitleLabel.numberOfLines = 0;
 
-
   self.authorsLabel = [[UILabel alloc] init];
   self.authorsLabel.autoresizingMask = UIViewAutoresizingFlexibleRightMargin;
   self.authorsLabel.numberOfLines = 0;
+
   if (UIDevice.currentDevice.userInterfaceIdiom == UIUserInterfaceIdiomPad &&
       [[TPPRootTabBarController sharedController] traitCollection].horizontalSizeClass != UIUserInterfaceSizeClassCompact) {
     self.authorsLabel.text = self.book.authors;
@@ -347,10 +355,10 @@ static NSString *DetailHTMLTemplate = nil;
 
   self.downloadFailedView = [[TPPBookDetailDownloadFailedView alloc] init];
   self.downloadFailedView.hidden = YES;
-  
+
   self.downloadingView = [[TPPBookDetailDownloadingView alloc] init];
   self.downloadingView.hidden = YES;
-  
+
   [self.containerView addSubview:self.normalView];
   [self.containerView addSubview:self.downloadFailedView];
   [self.containerView addSubview:self.downloadingView];
@@ -362,19 +370,19 @@ static NSString *DetailHTMLTemplate = nil;
   dateFormatter.timeStyle = NSDateFormatterNoStyle;
   dateFormatter.dateStyle = NSDateFormatterLongStyle;
   dateFormatter.timeZone = [NSTimeZone timeZoneForSecondsFromGMT:0];
-  
+
   NSString *const publishedKeyString =
   self.book.published
   ? [NSString stringWithFormat:@"%@: ",
      NSLocalizedString(@"Published", nil)]
   : nil;
-  
+
   NSString *const publisherKeyString =
   self.book.publisher
   ? [NSString stringWithFormat:@"%@: ",
      NSLocalizedString(@"Publisher", nil)]
   : nil;
-  
+
   NSString *const categoriesKeyString =
   self.book.categoryStrings.count
   ? [NSString stringWithFormat:@"%@: ",
@@ -384,18 +392,12 @@ static NSString *DetailHTMLTemplate = nil;
   : nil;
 
   NSString *const bookLanguageKeyString = [NSString stringWithFormat:@"%@: ",NSLocalizedString(@"Language", "")];
-  
   NSString *const bookFormatKeyString = [NSString stringWithFormat:@"%@: ",NSLocalizedString(@"Book format", nil)];
-  
   NSString *const isbnKeyString = [NSString stringWithFormat:@"%@: ",NSLocalizedString(@"ISBN", nil)];
-
   NSString *const narratorsKeyString =
     self.book.narrators ? [NSString stringWithFormat:@"%@: ", NSLocalizedString(@"Narrators", nil)] : nil;
-  
   NSString *const translatorsKeyString = self.book.translators ? [NSString stringWithFormat:@"%@: ", NSLocalizedString(@"Translators", nil)] : nil;
-  
   NSString *const illustratorsKeyString = self.book.illustrators ? [NSString stringWithFormat:@"%@: ", NSLocalizedString(@"Illustrators", nil)] : nil;
-  
   NSString *const bookDurationKeyString = [NSString stringWithFormat:@"%@:", NSLocalizedString(@"Duration", nil)];
 
   NSString *const categoriesValueString = self.book.categories;
@@ -408,7 +410,7 @@ static NSString *DetailHTMLTemplate = nil;
   }else{
     publishedValueString = self.book.published ? [dateFormatter stringFromDate:self.book.published] : nil;
   }
-  
+
   NSString *const publisherValueString = self.book.publisher;
   //NSString *const distributorKeyString = self.book.distributor ? [NSString stringWithFormat:NSLocalizedString(@"Distributed by: ", nil)] : nil;
   NSString *const bookFormatValueString = self.book.format;
@@ -420,12 +422,12 @@ static NSString *DetailHTMLTemplate = nil;
   NSString *const narratorsValueString = self.book.narrators;
   NSString *const illustratorsValueString = self.book.illustrators;
   NSString *const translatorsValueString = self.book.translators;
-  
+
   if (!categoriesValueString && !publishedValueString && !publisherValueString && !self.book.distributor) {
     self.topFootnoteSeparater.hidden = YES;
     self.bottomFootnoteSeparator.hidden = YES;
   }
-  
+
   self.bookLanguageLabelKey = [self createFooterLabelWithString:bookLanguageKeyString alignment:NSTextAlignmentRight];
   self.categoriesLabelKey = [self createFooterLabelWithString:categoriesKeyString alignment:NSTextAlignmentRight];
   self.publisherLabelKey = [self createFooterLabelWithString:publisherKeyString alignment:NSTextAlignmentRight];
@@ -451,14 +453,13 @@ static NSString *DetailHTMLTemplate = nil;
   self.translatorsLabelValue = [self createFooterLabelWithString:translatorsValueString alignment:NSTextAlignmentLeft];
   self.illustratorsLabelValue = [self createFooterLabelWithString:illustratorsValueString alignment:NSTextAlignmentLeft];
   self.bookDurationLabelValue = [self createFooterLabelWithString:[self displayStringForDuration: self.book.bookDuration] alignment:NSTextAlignmentLeft];
-
   self.narratorsLabelValue.numberOfLines = 0;
-  
+
   self.topFootnoteSeparater = [[UIView alloc] init];
   self.topFootnoteSeparater.backgroundColor = [TPPConfiguration inactiveIconColor]; //Edited by Ellibs
   self.bottomFootnoteSeparator = [[UIView alloc] init];
   self.bottomFootnoteSeparator.backgroundColor = [TPPConfiguration inactiveIconColor]; //Edited by Ellibs
-  
+
   self.footerTableView = [[TPPBookDetailTableView alloc] init];
   self.footerTableView.isAccessibilityElement = NO;
   self.tableViewDelegate = [[TPPBookDetailTableViewDelegate alloc] init:self.footerTableView book:self.book];
@@ -482,7 +483,6 @@ static NSString *DetailHTMLTemplate = nil;
   double totalSeconds = [durationInSeconds doubleValue];
   int hours = (int)(totalSeconds / 3600);
   int minutes = (int)((totalSeconds - (hours * 3600)) / 60);
-  
   return [NSString stringWithFormat:@"%d hours, %d minutes", hours, minutes];
 }
 
@@ -496,7 +496,6 @@ static NSString *DetailHTMLTemplate = nil;
     [self.audiobookSampleToolbar autoPinEdgeToSuperviewEdge:ALEdgeBottom withInset:TabBarHeight];
     [self.audiobookSampleToolbar autoSetDimension:ALDimensionHeight toSize:SampleToolbarHeight relation:NSLayoutRelationLessThanOrEqual];
     [self.audiobookSampleToolbar autoMatchDimension:ALDimensionWidth toDimension:ALDimensionWidth ofView:self];
-
     [self.scrollView autoPinEdge:ALEdgeBottom toEdge:ALEdgeTop ofView: self.audiobookSampleToolbar];
   } else {
     [self.scrollView autoPinEdgeToSuperviewEdge:ALEdgeBottom];
@@ -505,13 +504,13 @@ static NSString *DetailHTMLTemplate = nil;
   [self.scrollView autoPinEdgeToSuperviewEdge:ALEdgeLeft];
   [self.scrollView autoPinEdgeToSuperviewEdge:ALEdgeRight];
   [self.scrollView autoMatchDimension:ALDimensionWidth toDimension:ALDimensionWidth ofView:self.containerView];
-  
+
   [self.containerView autoPinEdgesToSuperviewEdges];
   [self.containerView autoMatchDimension:ALDimensionWidth toDimension:ALDimensionWidth ofView:self];
-  
+
   [self.visualEffectView autoPinEdgesToSuperviewEdgesWithInsets:UIEdgeInsetsZero excludingEdge:ALEdgeBottom];
   [self.visualEffectView autoPinEdge:ALEdgeBottom toEdge:ALEdgeTop ofView:self.normalView];
-  
+
   [self.coverImageView autoPinEdgeToSuperviewMargin:ALEdgeLeft]; //Edited by Ellibs
   [self.coverImageView autoPinEdgeToSuperviewEdge:ALEdgeTop withInset:VerticalPadding];
   [self.coverImageView autoMatchDimension:ALDimensionWidth toDimension:ALDimensionHeight ofView:self.coverImageView withMultiplier:CoverImageAspectRatio];
@@ -522,12 +521,17 @@ static NSString *DetailHTMLTemplate = nil;
   [self.blurCoverImageView autoPinEdge:ALEdgeBottom toEdge:ALEdgeBottom ofView:self.coverImageView];
 
   [TPPContentBadgeImageView pinWithBadge:self.contentTypeBadge toView:self.coverImageView isLane:NO];
-  
+
   [self.titleLabel autoPinEdge:ALEdgeLeading toEdge:ALEdgeTrailing ofView:self.coverImageView withOffset:MainTextPaddingLeft];
   [self.titleLabel autoPinEdge:ALEdgeTop toEdge:ALEdgeTop ofView:self.coverImageView];
   [self.titleLabel autoSetDimension:ALDimensionWidth toSize:TitleLabelMinimumWidth relation:NSLayoutRelationGreaterThanOrEqual];
-  NSLayoutConstraint *titleLabelConstraint = [self.titleLabel autoPinEdgeToSuperviewMargin:ALEdgeTrailing];
-  
+  [self.titleLabel autoPinEdge:ALEdgeTrailing toEdge:ALEdgeLeading ofView:self.selectionButtonsView];
+
+  [self.selectionButtonsView autoPinEdge:ALEdgeLeading toEdge:ALEdgeTrailing ofView:self.titleLabel];
+  [self.selectionButtonsView autoPinEdge:ALEdgeTop toEdge:ALEdgeTop ofView:self.coverImageView];
+  [self.selectionButtonsView autoSetDimension:ALDimensionWidth toSize:SelectionButtonMinimumWidth]; //relation:NSLayoutRelationGreaterThanOrEqual];
+  NSLayoutConstraint *selectionButtonConstraint = [self.selectionButtonsView autoPinEdgeToSuperviewMargin:ALEdgeTrailing];
+
   [self.subtitleLabel autoPinEdge:ALEdgeLeading toEdge:ALEdgeTrailing ofView:self.coverImageView withOffset:MainTextPaddingLeft];
   [self.subtitleLabel autoPinEdge:ALEdgeTrailing toEdge:ALEdgeTrailing ofView:self.titleLabel withOffset:10]; //Edited by Ellibs
   [self.subtitleLabel autoConstrainAttribute:ALAttributeTop toAttribute:ALAttributeBaseline ofView:self.titleLabel withOffset:SubtitleBaselineOffset];
@@ -549,16 +553,16 @@ static NSString *DetailHTMLTemplate = nil;
   } else {
     [self.authorsLabel autoConstrainAttribute:ALAttributeTop toAttribute:ALAttributeBaseline ofView:self.titleLabel withOffset:AuthorBaselineOffset];
   }
-  
+
   [self.buttonsView autoPinEdgeToSuperviewMargin:ALEdgeLeft];
   [self.buttonsView autoPinEdgeToSuperviewMargin:ALEdgeRight];
   [self.buttonsView autoPinEdge:ALEdgeTop toEdge:ALEdgeBottom ofView:self.coverImageView withOffset:VerticalPadding relation:NSLayoutRelationGreaterThanOrEqual];
-  
+
   [self.normalView autoPinEdge:ALEdgeTop toEdge:ALEdgeBottom ofView:self.buttonsView withOffset:VerticalPadding];
   [self.normalView autoPinEdgeToSuperviewEdge:ALEdgeRight];
   [self.normalView autoPinEdgeToSuperviewEdge:ALEdgeLeft];
   [self.normalView autoSetDimension:ALDimensionHeight toSize:NormalViewMinimumHeight relation:NSLayoutRelationGreaterThanOrEqual];
-  
+
   [self.downloadingView autoPinEdgeToSuperviewEdge:ALEdgeRight];
   [self.downloadingView autoPinEdgeToSuperviewEdge:ALEdgeLeft];
   [self.downloadingView autoPinEdge:ALEdgeTop toEdge:ALEdgeBottom ofView:self.buttonsView withOffset:VerticalPadding];
@@ -568,10 +572,10 @@ static NSString *DetailHTMLTemplate = nil;
   [self.downloadFailedView autoPinEdgeToSuperviewEdge:ALEdgeLeft];
   [self.downloadFailedView autoPinEdge:ALEdgeTop toEdge:ALEdgeBottom ofView:self.buttonsView withOffset:VerticalPadding];
   [self.downloadFailedView autoConstrainAttribute:ALAttributeHeight toAttribute:ALAttributeHeight ofView:self.normalView];
-  
+
   [self.summarySectionLabel autoPinEdgeToSuperviewMargin:ALEdgeLeading];
   [self.summarySectionLabel autoPinEdge:ALEdgeTop toEdge:ALEdgeBottom ofView:self.normalView withOffset:VerticalPadding + 4];
-  
+
   [self.summaryTextView autoPinEdge:ALEdgeTop toEdge:ALEdgeBottom ofView:self.summarySectionLabel withOffset:VerticalPadding];
   [self.summaryTextView autoPinEdgeToSuperviewMargin:ALEdgeTrailing];
   [self.summaryTextView autoPinEdgeToSuperviewMargin:ALEdgeLeading];
@@ -581,27 +585,27 @@ static NSString *DetailHTMLTemplate = nil;
   [self.readMoreLabel autoPinEdgeToSuperviewMargin:ALEdgeTrailing];
   [self.readMoreLabel autoPinEdge:ALEdgeTop toEdge:ALEdgeBottom ofView:self.summaryTextView];
   [self.readMoreLabel autoPinEdge:ALEdgeBottom toEdge:ALEdgeTop ofView:self.topFootnoteSeparater withOffset:-15]; //Edited by Ellibs
-  
+
   [self.infoSectionLabel autoPinEdgeToSuperviewMargin:ALEdgeLeading];
-  
+
   [self.publishedLabelValue autoPinEdgeToSuperviewMargin:ALEdgeTrailing relation:NSLayoutRelationGreaterThanOrEqual];
   [self.publishedLabelValue autoPinEdge:ALEdgeTop toEdge:ALEdgeBottom ofView:self.bookLanguageLabelValue];
   [self.publishedLabelValue autoPinEdge:ALEdgeLeading toEdge:ALEdgeTrailing ofView:self.publishedLabelKey withOffset:MainTextPaddingLeft];
-  
+
   [self.publisherLabelValue autoPinEdgeToSuperviewMargin:ALEdgeTrailing relation:NSLayoutRelationGreaterThanOrEqual];
   [self.publisherLabelValue autoPinEdge:ALEdgeTop toEdge:ALEdgeBottom ofView:self.publishedLabelValue];
   [self.publisherLabelValue autoPinEdge:ALEdgeLeading toEdge:ALEdgeTrailing ofView:self.publisherLabelKey withOffset:MainTextPaddingLeft];
-  
+
   if (self.bookLanguageLabelValue.text) {
     [self.bookLanguageLabelValue autoPinEdgeToSuperviewMargin:ALEdgeTrailing relation:NSLayoutRelationGreaterThanOrEqual];
     [self.bookLanguageLabelValue autoPinEdge:ALEdgeTop toEdge:ALEdgeBottom ofView:self.infoSectionLabel withOffset:VerticalPadding];
     [self.bookLanguageLabelValue autoPinEdge:ALEdgeLeading toEdge:ALEdgeTrailing ofView:self.bookLanguageLabelKey withOffset:MainTextPaddingLeft];
   }
-  
+
   [self.categoriesLabelValue autoPinEdgeToSuperviewMargin:ALEdgeTrailing relation:NSLayoutRelationGreaterThanOrEqual];
   [self.categoriesLabelValue autoPinEdge:ALEdgeTop toEdge:ALEdgeBottom ofView:self.publisherLabelValue];
   [self.categoriesLabelValue autoPinEdge:ALEdgeLeading toEdge:ALEdgeTrailing ofView:self.categoriesLabelKey withOffset:MainTextPaddingLeft];
-  
+
   /*[self.distributorLabelValue autoPinEdgeToSuperviewMargin:ALEdgeTrailing relation:NSLayoutRelationGreaterThanOrEqual];
   [self.distributorLabelValue autoPinEdge:ALEdgeTop toEdge:ALEdgeBottom ofView:self.categoriesLabelValue];
   [self.distributorLabelValue autoPinEdge:ALEdgeLeading toEdge:ALEdgeTrailing ofView:self.distributorLabelKey withOffset:MainTextPaddingLeft];*/
@@ -609,7 +613,7 @@ static NSString *DetailHTMLTemplate = nil;
   [self.bookFormatLabelValue autoPinEdgeToSuperviewMargin:ALEdgeTrailing relation:NSLayoutRelationGreaterThanOrEqual];
   [self.bookFormatLabelValue autoPinEdge:ALEdgeTop toEdge:ALEdgeBottom ofView:self.categoriesLabelValue];
   [self.bookFormatLabelValue autoPinEdge:ALEdgeLeading toEdge:ALEdgeTrailing ofView:self.bookFormatLabelKey withOffset:MainTextPaddingLeft];
-  
+
   [self.isbnLabelValue autoPinEdgeToSuperviewMargin:ALEdgeTrailing relation:NSLayoutRelationGreaterThanOrEqual];
   [self.isbnLabelValue autoPinEdge:ALEdgeTop toEdge:ALEdgeBottom ofView:self.bookFormatLabelValue];
   [self.isbnLabelValue autoPinEdge:ALEdgeLeading toEdge:ALEdgeTrailing ofView:self.isbnLabelKey withOffset:MainTextPaddingLeft];
@@ -617,11 +621,11 @@ static NSString *DetailHTMLTemplate = nil;
   [self.translatorsLabelValue autoPinEdgeToSuperviewMargin:ALEdgeTrailing relation:NSLayoutRelationGreaterThanOrEqual];
   [self.translatorsLabelValue autoPinEdge:ALEdgeTop toEdge:ALEdgeBottom ofView:self.isbnLabelValue];
   [self.translatorsLabelValue autoPinEdge:ALEdgeLeading toEdge:ALEdgeTrailing ofView:self.translatorsLabelKey withOffset:MainTextPaddingLeft];
-  
+
   [self.narratorsLabelValue autoPinEdgeToSuperviewMargin:ALEdgeTrailing relation:NSLayoutRelationGreaterThanOrEqual];
   [self.narratorsLabelValue autoPinEdge:ALEdgeTop toEdge:ALEdgeBottom ofView:self.translatorsLabelValue];
   [self.narratorsLabelValue autoPinEdge:ALEdgeLeading toEdge:ALEdgeTrailing ofView:self.narratorsLabelKey withOffset:MainTextPaddingLeft];
-  
+
   [self.illustratorsLabelValue autoPinEdgeToSuperviewMargin:ALEdgeTrailing relation:NSLayoutRelationGreaterThanOrEqual];
   [self.illustratorsLabelValue autoPinEdge:ALEdgeTop toEdge:ALEdgeBottom ofView:self.narratorsLabelValue];
   [self.illustratorsLabelValue autoPinEdge:ALEdgeLeading toEdge:ALEdgeTrailing ofView:self.illustratorsLabelKey withOffset:MainTextPaddingLeft];
@@ -642,12 +646,12 @@ static NSString *DetailHTMLTemplate = nil;
   [self.publisherLabelKey autoPinEdge:ALEdgeTrailing toEdge:ALEdgeTrailing ofView:self.bookLanguageLabelKey];
   [self.publisherLabelKey autoPinEdge:ALEdgeTop toEdge:ALEdgeTop ofView:self.publisherLabelValue];
   [self.publisherLabelKey setContentCompressionResistancePriority:UILayoutPriorityRequired forAxis:UILayoutConstraintAxisHorizontal];
-  
+
   [self.bookLanguageLabelKey autoPinEdgeToSuperviewMargin:ALEdgeLeading];
   [self.bookLanguageLabelKey autoPinEdge:ALEdgeTrailing toEdge:ALEdgeTrailing ofView:self.bookFormatLabelKey];
   [self.bookLanguageLabelKey autoPinEdge:ALEdgeTop toEdge:ALEdgeTop ofView:self.bookLanguageLabelValue];
   [self.bookLanguageLabelKey setContentCompressionResistancePriority:UILayoutPriorityRequired forAxis:UILayoutConstraintAxisHorizontal];
-  
+
   [self.categoriesLabelKey autoPinEdgeToSuperviewMargin:ALEdgeLeading];
   [self.categoriesLabelKey autoPinEdge:ALEdgeTrailing toEdge:ALEdgeTrailing ofView:self.bookFormatLabelKey];
   [self.categoriesLabelKey autoPinEdge:ALEdgeTop toEdge:ALEdgeTop ofView:self.categoriesLabelValue];
@@ -667,17 +671,17 @@ static NSString *DetailHTMLTemplate = nil;
   [self.isbnLabelKey autoPinEdge:ALEdgeTrailing toEdge:ALEdgeTrailing ofView:self.translatorsLabelKey];
   [self.isbnLabelKey autoPinEdge:ALEdgeTop toEdge:ALEdgeTop ofView:self.isbnLabelValue];
   [self.isbnLabelKey setContentCompressionResistancePriority:UILayoutPriorityRequired forAxis:UILayoutConstraintAxisHorizontal];
-  
+
   [self.translatorsLabelKey autoPinEdgeToSuperviewMargin:ALEdgeLeading];
   [self.translatorsLabelKey autoPinEdge:ALEdgeTrailing toEdge:ALEdgeTrailing ofView:self.narratorsLabelKey];
   [self.translatorsLabelKey autoPinEdge:ALEdgeTop toEdge:ALEdgeTop ofView:self.translatorsLabelValue];
   [self.translatorsLabelKey setContentCompressionResistancePriority:UILayoutPriorityRequired forAxis:UILayoutConstraintAxisHorizontal];
-  
+
   [self.narratorsLabelKey autoPinEdgeToSuperviewMargin:ALEdgeLeading];
   [self.narratorsLabelKey autoPinEdge:ALEdgeTrailing toEdge:ALEdgeTrailing ofView:self.illustratorsLabelKey];
   [self.narratorsLabelKey autoPinEdge:ALEdgeTop toEdge:ALEdgeTop ofView:self.narratorsLabelValue];
   [self.narratorsLabelKey setContentCompressionResistancePriority:UILayoutPriorityRequired forAxis:UILayoutConstraintAxisHorizontal];
-  
+
   [self.illustratorsLabelKey autoPinEdgeToSuperviewMargin:ALEdgeLeading];
   [self.illustratorsLabelKey autoPinEdge:ALEdgeTop toEdge:ALEdgeTop ofView:self.illustratorsLabelValue];
   [self.illustratorsLabelKey setContentCompressionResistancePriority:UILayoutPriorityRequired forAxis:UILayoutConstraintAxisHorizontal];
@@ -688,21 +692,21 @@ static NSString *DetailHTMLTemplate = nil;
     [self.bookDurationLabelKey autoPinEdge:ALEdgeTrailing toEdge:ALEdgeTrailing ofView:self.illustratorsLabelKey];
     [self.bookDurationLabelKey setContentCompressionResistancePriority:UILayoutPriorityRequired forAxis:UILayoutConstraintAxisHorizontal];
   }
-  
+
   if (self.closeButton) {
     [self.closeButton autoPinEdgeToSuperviewMargin:ALEdgeTrailing];
     [self.closeButton autoPinEdge:ALEdgeTop toEdge:ALEdgeTop ofView:self.titleLabel];
     [self.closeButton autoSetDimension:ALDimensionWidth toSize:80 relation:NSLayoutRelationLessThanOrEqual];
-    [NSLayoutConstraint deactivateConstraints:@[titleLabelConstraint]];
+    [NSLayoutConstraint deactivateConstraints:@[selectionButtonConstraint]];
     [self.closeButton autoPinEdge:ALEdgeLeading toEdge:ALEdgeTrailing ofView:self.titleLabel withOffset:MainTextPaddingLeft];
     [self.closeButton setContentCompressionResistancePriority:UILayoutPriorityRequired forAxis:UILayoutConstraintAxisHorizontal];
   }
-  
+
   [self.topFootnoteSeparater autoSetDimension:ALDimensionHeight toSize: 1.0f / [UIScreen mainScreen].scale];
   [self.topFootnoteSeparater autoPinEdgeToSuperviewEdge:ALEdgeRight];
   [self.topFootnoteSeparater autoPinEdgeToSuperviewMargin:ALEdgeLeft];
   [self.topFootnoteSeparater autoPinEdge:ALEdgeBottom toEdge:ALEdgeTop ofView:self.infoSectionLabel withOffset:-VerticalPadding];
-  
+
   [self.bottomFootnoteSeparator autoSetDimension:ALDimensionHeight toSize: 1.0f / [UIScreen mainScreen].scale];
   [self.bottomFootnoteSeparator autoPinEdgeToSuperviewEdge:ALEdgeRight];
   [self.bottomFootnoteSeparator autoPinEdgeToSuperviewMargin:ALEdgeLeft];
@@ -712,9 +716,10 @@ static NSString *DetailHTMLTemplate = nil;
   } else {
     [self.bottomFootnoteSeparator autoPinEdge:ALEdgeTop toEdge:ALEdgeBottom ofView:self.illustratorsLabelValue withOffset:VerticalPadding];
   }
-  
+
   [self.footerTableView autoPinEdgesToSuperviewEdgesWithInsets:UIEdgeInsetsMake(0, 10, 0, 0) excludingEdge:ALEdgeTop];
   [self.footerTableView autoPinEdge:ALEdgeTop toEdge:ALEdgeBottom ofView:self.illustratorsLabelValue withOffset:VerticalPadding];
+
 }
 
 #pragma mark NSObject
@@ -797,16 +802,20 @@ NSString *PlaySampleNotification = @"ToggleSampleNotification";
       self.downloadFailedView.hidden = YES;
       [self hideDownloadingView:YES];
       self.buttonsView.hidden = NO;
+      self.selectionButtonsView.hidden = NO;
       self.normalView.state = TPPBookButtonsViewStateWithAvailability(self.book.defaultAcquisition.availability);
       self.buttonsView.state = self.normalView.state;
+      self.selectionButtonsView.selectionState = BookSelectionButtonsViewStateWithBook(self.book);
       break;
     case TPPBookStateDownloadNeeded:
       self.normalView.hidden = NO;
       self.downloadFailedView.hidden = YES;
       [self hideDownloadingView:YES];
       self.buttonsView.hidden = NO;
+      self.selectionButtonsView.hidden = NO;
       self.normalView.state = TPPBookButtonsStateDownloadNeeded;
       self.buttonsView.state = TPPBookButtonsStateDownloadNeeded;
+      self.selectionButtonsView.selectionState = BookSelectionButtonsViewStateWithBook(self.book);
       break;
     case TPPBookStateSAMLStarted:
       self.downloadingView.downloadProgress = 0;
@@ -815,46 +824,58 @@ NSString *PlaySampleNotification = @"ToggleSampleNotification";
       self.downloadFailedView.hidden = YES;
       [self hideDownloadingView:NO];
       self.buttonsView.hidden = NO;
+      self.selectionButtonsView.hidden = NO;
       self.buttonsView.state = TPPBookButtonsStateDownloadInProgress;
+      self.selectionButtonsView.selectionState = BookSelectionButtonsViewStateWithBook(self.book);
       break;
     case TPPBookStateDownloadFailed:
       [self.downloadFailedView configureFailMessageWithProblemDocument:[[TPPProblemDocumentCacheManager shared] getLastCachedDoc:self.book.identifier]];
       self.downloadFailedView.hidden = NO;
       [self hideDownloadingView:YES];
       self.buttonsView.hidden = NO;
+      self.selectionButtonsView.hidden = NO;
       self.buttonsView.state = TPPBookButtonsStateDownloadFailed;
+      self.selectionButtonsView.selectionState = BookSelectionButtonsViewStateWithBook(self.book);
       break;
     case TPPBookStateDownloadSuccessful:
       self.normalView.hidden = NO;
       self.downloadFailedView.hidden = YES;
       [self hideDownloadingView:YES];
       self.buttonsView.hidden = NO;
+      self.selectionButtonsView.hidden = NO;
       self.normalView.state = TPPBookButtonsStateDownloadSuccessful;
       self.buttonsView.state = TPPBookButtonsStateDownloadSuccessful;
+      self.selectionButtonsView.selectionState = BookSelectionButtonsViewStateWithBook(self.book);
       break;
     case TPPBookStateHolding:
       self.normalView.hidden = NO;
       self.downloadFailedView.hidden = YES;
       [self hideDownloadingView:YES];
       self.buttonsView.hidden = NO;
+      self.selectionButtonsView.hidden = NO;
       self.normalView.state = TPPBookButtonsViewStateWithAvailability(self.book.defaultAcquisition.availability);
       self.buttonsView.state = self.normalView.state;
+      self.selectionButtonsView.selectionState = BookSelectionButtonsViewStateWithBook(self.book);
       break;
     case TPPBookStateUsed:
       self.normalView.hidden = NO;
       self.downloadFailedView.hidden = YES;
       [self hideDownloadingView:YES];
       self.buttonsView.hidden = NO;
+      self.selectionButtonsView.hidden = NO;
       self.normalView.state = TPPBookButtonsStateUsed;
       self.buttonsView.state = TPPBookButtonsStateUsed;
+      self.selectionButtonsView.selectionState = BookSelectionButtonsViewStateWithBook(self.book);
       break;
     case TPPBookStateUnsupported:
       self.normalView.hidden = NO;
       self.downloadFailedView.hidden = YES;
       [self hideDownloadingView:YES];
       self.buttonsView.hidden = NO;
+      self.selectionButtonsView.hidden = NO;
       self.normalView.state = TPPBookButtonsStateUnsupported;
       self.buttonsView.state = TPPBookButtonsStateUnsupported;
+      self.selectionButtonsView.selectionState = BookSelectionButtonsViewStateWithBook(self.book);
       break;
   }
 }

--- a/Palace/Book/UI/BookDetailView/TPPBookDetailView.m
+++ b/Palace/Book/UI/BookDetailView/TPPBookDetailView.m
@@ -913,6 +913,7 @@ NSString *PlaySampleNotification = @"ToggleSampleNotification";
   _book = book;
   self.normalView.book = book;
   self.buttonsView.book = book;
+  self.selectionButtonsView.book = book;
 }
 
 - (double)downloadProgress

--- a/Palace/Book/UI/BookDetailView/TPPBookDetailViewController.m
+++ b/Palace/Book/UI/BookDetailView/TPPBookDetailViewController.m
@@ -53,6 +53,9 @@
   self.bookDetailView.state = [[TPPBookRegistry shared]
                                stateFor:self.book.identifier];
 
+  self.bookDetailView.selectionState = [[TPPBookRegistry shared]
+                               selectionStateFor:self.book.identifier];
+
   if(UIDevice.currentDevice.userInterfaceIdiom == UIUserInterfaceIdiomPad &&
      [[TPPRootTabBarController sharedController] traitCollection].horizontalSizeClass != UIUserInterfaceSizeClassCompact) {
     self.modalPresentationStyle = UIModalPresentationFormSheet;
@@ -103,6 +106,9 @@
   
   [self.bookDetailView setState:[[TPPBookRegistry shared]
                                  stateFor:self.book.identifier]];
+
+  [self.bookDetailView setSelectionState:[[TPPBookRegistry shared] selectionStateFor:self.book.identifier]];
+
 }
 
 - (void)viewDidAppear:(BOOL)animated
@@ -315,6 +321,7 @@
       self.bookDetailView.book = newBook;
     }
     self.bookDetailView.state = [registry stateFor:self.book.identifier];
+    self.bookDetailView.selectionState = [registry selectionStateFor:self.book.identifier];
   }];
 }
 

--- a/Palace/MyBooks/Views/SharedUIComponents/BookCell/BookCellModel.swift
+++ b/Palace/MyBooks/Views/SharedUIComponents/BookCell/BookCellModel.swift
@@ -109,7 +109,7 @@ class BookCellModel: ObservableObject {
 
     self.image = cachedImage
   }
-  
+
   // This function is used in NormalBookCell views
   // when we need to know if the book is for example already in loan for user
   func bookCellBookButtonState(book: TPPBook) -> BookButtonState {
@@ -148,6 +148,7 @@ class BookCellModel: ObservableObject {
 }
 
 extension BookCellModel {
+
   func callDelegate(for action: BookButtonType) {
     switch action {
     case .download, .retry, .get, .reserve:
@@ -158,6 +159,10 @@ extension BookCellModel {
       didSelectCancel()
     case .read, .listen:
       didSelectRead()
+    case .select:
+      didSelectSelect()
+    case .unselect:
+      didSelectUnselect()
     }
   }
 
@@ -238,4 +243,18 @@ extension BookCellModel {
   func didSelectCancel() {
     MyBooksDownloadCenter.shared.cancelDownload(for: book.identifier)
   }
+
+  func didSelectSelect() {
+    isLoading = true
+    self.buttonDelegate?.didSelectSelect(for: book)
+    TPPRootTabBarController.shared().dismiss(animated: true)
+  }
+
+  func didSelectUnselect() {
+    isLoading = true
+    self.buttonDelegate?.didSelectUnselect(for: book)
+    TPPRootTabBarController.shared().dismiss(animated: true)
+  }
+
 }
+

--- a/Palace/MyBooks/Views/SharedUIComponents/BookCell/BookCellModel.swift
+++ b/Palace/MyBooks/Views/SharedUIComponents/BookCell/BookCellModel.swift
@@ -66,6 +66,10 @@ class BookCellModel: ObservableObject {
     state.buttonState.buttonTypes(book: book)
   }
 
+  var secondaryButtonTypes: [BookButtonType] {
+    state.buttonState.secondaryButtonTypes(book: book)
+  }
+
   private weak var buttonDelegate = TPPBookCellDelegate.shared()
   private weak var downloadDelegate: TPPBookDownloadCancellationDelegate?
 

--- a/Palace/MyBooks/Views/SharedUIComponents/BookCell/NormalBookCell.swift
+++ b/Palace/MyBooks/Views/SharedUIComponents/BookCell/NormalBookCell.swift
@@ -22,7 +22,11 @@ struct NormalBookCell: View {
         //unreadImageView
         titleCoverImageView
         VStack(alignment: .leading) {
-          bookInfoView
+          HStack(alignment: .top) {
+            bookInfoView
+            Spacer()
+            secondaryButtonsView
+          }
           Spacer()
         }
         .padding(.leading, 8)
@@ -62,7 +66,6 @@ struct NormalBookCell: View {
     }
     .opacity(model.showUnreadIndicator ? 1.0 : 0.0)
   }
- 
 
   @ViewBuilder private var titleCoverImageView: some View {
     ZStack {
@@ -124,6 +127,21 @@ struct NormalBookCell: View {
     }
   }
 
+  @ViewBuilder private var secondaryButtonsView: some View {
+    HStack {
+      ForEach(model.secondaryButtonTypes, id: \.self) { type in
+        IconButtonView(
+          title: type.localizedTitle,
+          indicatorDate: model.indicatorDate(for: type),
+          action: { model.callDelegate(for: type) }
+        )
+        .disabled(type.isDisabled)
+        .opacity(type.isDisabled ? 0.5 : 1.0)
+      }
+    }
+    .padding(.leading, 10)
+  }
+
   @ViewBuilder private var bookStateInfoView: some View {
 
     let infoText: String = getInfoText()
@@ -173,9 +191,9 @@ struct NormalBookCell: View {
         return normalCellHeightForPad
 
       case .phone:
-       return infoText.isEmpty
-        ? normalCellHeightForPhone
-        : largerCellHeightForPhone
+        return infoText.isEmpty
+          ? normalCellHeightForPhone
+          : largerCellHeightForPhone
 
       default:
         return 250

--- a/Palace/MyBooks/Views/SharedUIComponents/ButtonView/BookButtonState.swift
+++ b/Palace/MyBooks/Views/SharedUIComponents/ButtonView/BookButtonState.swift
@@ -22,6 +22,7 @@ enum BookButtonState {
 }
 
 extension BookButtonState {
+
   func buttonTypes(book: TPPBook) -> [BookButtonType] {
     var buttons = [BookButtonType]()
 
@@ -75,6 +76,19 @@ extension BookButtonState {
 
     return buttons
   }
+
+  func secondaryButtonTypes(book: TPPBook) -> [BookButtonType] {
+    var secondaryButtonTypes = [BookButtonType]()
+
+    if TPPBookRegistry.shared.selectionState(for: book.identifier) == .Selected {
+      secondaryButtonTypes.append(.unselect)
+    } else {
+      secondaryButtonTypes.append(.select)
+    }
+
+    return secondaryButtonTypes
+  }
+
 }
 
 extension BookButtonState {

--- a/Palace/MyBooks/Views/SharedUIComponents/ButtonView/BookButtonType.swift
+++ b/Palace/MyBooks/Views/SharedUIComponents/ButtonView/BookButtonType.swift
@@ -18,6 +18,8 @@ enum BookButtonType: String {
   case cancel
   case remove
   case `return`
+  case select
+  case unselect
 
   var localizedTitle: String {
     NSLocalizedString(

--- a/Palace/MyBooks/Views/SharedUIComponents/ButtonView/ButtonView.swift
+++ b/Palace/MyBooks/Views/SharedUIComponents/ButtonView/ButtonView.swift
@@ -9,22 +9,23 @@
 import SwiftUI
 
 struct ButtonView: View {
-  
+
   var title: String
   var indicatorDate: Date? = nil
   var backgroundFill: Color? = nil
   var action: () -> Void
-  
+
   private var accessiblityString: String {
-    guard let untilDate = indicatorDate?.timeUntilString(suffixType: .long) else {
+    guard let untilDate = indicatorDate?.timeUntilString(suffixType: .long)
+    else {
       return title
     }
 
     return "\(title).\(untilDate) remaining"
   }
-    
+
   var body: some View {
-    Button (action: action) {
+    Button(action: action) {
       HStack(alignment: .center, spacing: 5) {
         //indicatorView
         Text(title)
@@ -33,11 +34,18 @@ struct ButtonView: View {
       .frame(minWidth: 0, maxWidth: .infinity)
     }
     .font(Font(uiFont: UIFont.palaceFont(ofSize: 14)))
-    .foregroundColor(indicatorDate != nil ? Color("ColorEkirjastoButtonTextWithBackground") : Color("ColorEkirjastoLabel"))
-    .buttonStyle(AnimatedButton(backgroundColor: indicatorDate != nil ? Color("ColorEkirjastoLightestGreen") : backgroundFill))
+    .foregroundColor(indicatorDate != nil
+        ? Color("ColorEkirjastoButtonTextWithBackground")
+        : Color("ColorEkirjastoLabel")
+    )
+    .buttonStyle(
+      AnimatedButton(backgroundColor: indicatorDate != nil
+        ? Color("ColorEkirjastoLightestGreen")
+        : backgroundFill)
+    )
     .accessibilityLabel(accessiblityString)
   }
-  
+
   /*
    This view is not currently used in My books views,
    as loan time is shown separately and
@@ -58,6 +66,55 @@ struct ButtonView: View {
   }
 }
 
+struct IconButtonView: View {
+
+  var buttonImageForSelectedBook: Image = ImageProviders.MyBooksView.selectionIconCheck
+  var buttonImageForUnselectedBook: Image = ImageProviders.MyBooksView.selectionIconPlus
+  var title: String
+  var indicatorDate: Date? = nil
+  var backgroundFill: Color? = nil
+  var action: () -> Void
+
+  private var accessiblityString: String {
+    "Add or remove book from favorites"
+  }
+
+  var body: some View {
+    Button(action: action) {
+
+      HStack(alignment: .center) {
+        if title == "Select" {
+          buttonImageForUnselectedBook
+            .resizable()
+            .square(length: 25)
+            .foregroundColor(Color("ColorEkirjastoButtonTextWithBackground"))
+        } else if title == "Unselect" {
+          buttonImageForSelectedBook
+            .resizable()
+            .square(length: 25)
+            .foregroundColor(Color("ColorEkirjastoButtonTextWithBackground"))
+        } else {
+          EmptyView()
+        }
+      }
+    }
+    .font(Font(uiFont: UIFont.palaceFont(ofSize: 14)))
+    .fixedSize()
+    .foregroundColor(
+      indicatorDate != nil
+        ? Color("ColorEkirjastoButtonTextWithBackground")
+        : Color("ColorEkirjastoLabel")
+    )
+    .buttonStyle(
+      AnimatedButtonWithoutOverlay(
+        backgroundColor: indicatorDate != nil
+          ? Color("ColorEkirjastoLightestGreen")
+          : backgroundFill)
+    )
+    .accessibilityLabel(accessiblityString)
+  }
+}
+
 struct AnimatedButton: ButtonStyle {
   var backgroundColor: Color? = nil
 
@@ -70,6 +127,18 @@ struct AnimatedButton: ButtonStyle {
         RoundedRectangle(cornerRadius: 3)
           .stroke(Color("ColorEkirjastoGreen"), lineWidth: 1)
       )
+      .opacity(configuration.isPressed ? 0.5 : 1.0)
+  }
+}
+
+struct AnimatedButtonWithoutOverlay: ButtonStyle {
+  var backgroundColor: Color? = nil
+
+  func makeBody(configuration: Configuration) -> some View {
+    configuration.label
+      .frame(height: 35)
+      .buttonStyle(.plain)
+      .background(backgroundColor)
       .opacity(configuration.isPressed ? 0.5 : 1.0)
   }
 }

--- a/Palace/Utilities/SwiftUI/ImageProvider.swift
+++ b/Palace/Utilities/SwiftUI/ImageProvider.swift
@@ -9,6 +9,7 @@
 import SwiftUI
 
 struct ImageProviders {
+
   struct AudiobookSampleToolbar {
     static let pause = Image(systemName: "pause.circle")
     static let play = Image(systemName: "play.circle")
@@ -22,5 +23,8 @@ struct ImageProviders {
     static let clock = Image("Clock")
     static let myLibraryIcon = Image("MyLibraryIcon")
     static let search = Image("Search")
+    static let selectionIconPlus = Image("BookmarkOff")   // TODO: replace placeholder image
+    static let selectionIconCheck = Image("BookmarkOn") // TODO: replace placeholder image
   }
+
 }

--- a/Palace/Utilities/SwiftUI/ImageProvider.swift
+++ b/Palace/Utilities/SwiftUI/ImageProvider.swift
@@ -7,6 +7,7 @@
 //
 
 import SwiftUI
+import UIKit
 
 struct ImageProviders {
 
@@ -15,7 +16,7 @@ struct ImageProviders {
     static let play = Image(systemName: "play.circle")
     static let stepBack = Image(systemName: "gobackward.30")
   }
-  
+
   struct MyBooksView {
     static let bookPlaceholder = UIImage(systemName: "book.closed.fill")
     static let audiobookBadge = Image("AudiobookBadge")
@@ -23,8 +24,14 @@ struct ImageProviders {
     static let clock = Image("Clock")
     static let myLibraryIcon = Image("MyLibraryIcon")
     static let search = Image("Search")
-    static let selectionIconPlus = Image("BookmarkOff")   // TODO: replace placeholder image
+    static let selectionIconPlus = Image("BookmarkOff") // TODO: replace placeholder image
     static let selectionIconCheck = Image("BookmarkOn") // TODO: replace placeholder image
   }
 
+}
+
+// UIKit Images for Objective-C code
+@objc public class ImageProvidersMyBooksViewObjcClass: NSObject {
+  @objc static let selectionIconPlus = UIImage(named: "BookmarkOff") // TODO: replace placeholder image
+  @objc static let selectionIconCheck = UIImage(named: "BookmarkOn") // TODO: replace placeholder image
 }


### PR DESCRIPTION
## Major changes and updates in this subtask

### There is now a favorite button in book views
- new icon button for favorite action was added to the book detail view and book list views
- favorite button was added to the right of the book title, on top right corner of book cells and book detail view
  - for iPad book detail view, the favorite button is located between the book title and the close button

### Favorite button toggles between two icons
- if the user has added the book to favorites, the user is shown a button icon to remove the book from favorites
  - otherwise, the user is shown a button icon to add the book to favorites
  - button icon to add the book to favorites is shown also for unregistered books
- favorite button icons can be easily updated later in the ImageProvider.swift file

### New button view was created for Objective-C views
- favorite button is displayed by _selectionButtonView_
- the selection buttons use selection button states _CanSelect_ and _CanUnselect_

### New button view was created for SwiftUI views
- favorite button is displayed by the new IconButtonView
- the button icon is determined by the book selection state
