### PR TITLE
EKIRJASTO-111 Check token refresh

### DIFF
--- a/Palace/Accounts/Library/Account.swift
+++ b/Palace/Accounts/Library/Account.swift
@@ -40,6 +40,7 @@ protocol AccountLogoDelegate: AnyObject {
     case oauthIntermediary = "http://librarysimplified.org/authtype/OAuth-with-intermediary"
     case saml = "http://librarysimplified.org/authtype/SAML-2.0"
     case token = "http://thepalaceproject.org/authtype/basic-token"
+    case ekirjasto = "http://e-kirjasto.fi/authtype/ekirjasto"
     case none
   }
   
@@ -96,12 +97,13 @@ protocol AccountLogoDelegate: AnyObject {
         coppaOverUrl = nil
         tokenURL = nil
 
-      case .none, .basic, .anonymous:
+      case .none, .basic, .anonymous, .ekirjasto:
         oauthIntermediaryUrl = nil
         coppaUnderUrl = nil
         coppaOverUrl = nil
         samlIdps = nil
         tokenURL = nil
+        
       case .token:
         tokenURL = URL.init(string: auth.links?.first(where: { $0.rel == "authenticate" })?.href ?? "")
         oauthIntermediaryUrl = nil
@@ -138,6 +140,10 @@ protocol AccountLogoDelegate: AnyObject {
 
     var isToken: Bool {
       authType == .token
+    }
+    
+    var isEkirjasto: Bool {
+      authType == .ekirjasto
     }
     
     var catalogRequiresAuthentication: Bool {

--- a/Palace/Fonts/Ekirjasto/UIFont+Ekirjasto.swift
+++ b/Palace/Fonts/Ekirjasto/UIFont+Ekirjasto.swift
@@ -35,7 +35,6 @@ extension UIFont {
       let baseFontSize = UIFont.preferredFont(forTextStyle: textStyle).pointSize
       let setFontSize: CGFloat
       setFontSize = baseFontSize * fontMultiplier
-      //print("Adjusted size: \(setFontSize), multiplier: \(fontMultiplier) in PalaceFont")
       let font = UIFont(name: TPPConfiguration.ekirjastoFontName(), size: setFontSize) ?? UIFont.systemFont(ofSize: setFontSize, weight: weight)
       return font
       // Apply system font size adjustment to the given size
@@ -62,7 +61,6 @@ extension UIFont {
       let baseFontSize = UIFont.preferredFont(forTextStyle: textStyle).pointSize
       let setFontSize: CGFloat
       setFontSize = baseFontSize * fontMultiplier
-      //print("Adjusted size: \(setFontSize), multiplier: \(fontMultiplier) in semiBoldPalaceFont")
       let font = UIFont(name: TPPConfiguration.ekirjastoFontName(), size: setFontSize) ?? UIFont.systemFont(ofSize: setFontSize, weight: weight)
       return font
       // Apply system font size adjustment to the given size
@@ -89,7 +87,6 @@ extension UIFont {
       let baseFontSize = UIFont.preferredFont(forTextStyle: textStyle).pointSize
       let setFontSize: CGFloat
       setFontSize = baseFontSize * fontMultiplier
-      //print("Adjusted size: \(setFontSize), multiplier: \(fontMultiplier) in boldPalaceFont")
       let font = UIFont(name: TPPConfiguration.ekirjastoFontName(), size: setFontSize) ?? UIFont.systemFont(ofSize: setFontSize, weight: weight)
       return font
       // Apply system font size adjustment to the given size
@@ -125,7 +122,6 @@ extension UIFont {
     if fontSizeAdjusted {
       // Apply user font size adjustment to the given font size
       setFontSize = fontSize * fontMultiplier
-      //print("Adjusted size: \(setFontSize), multiplier: \(fontMultiplier) in palaceFont")
       let font = UIFont(name: TPPConfiguration.ekirjastoFontName(), size: setFontSize) ?? UIFont.systemFont(ofSize: setFontSize)
       return font
     // Apply system font size adjustment to the given size
@@ -154,7 +150,6 @@ extension UIFont {
     if fontSizeAdjusted {
       // Apply user font size adjustment to the given font size
       setFontSize = fontSize * fontMultiplier
-      //print("Adjusted size: \(setFontSize), multiplier: \(fontMultiplier) in semiBoldPalace")
       let font = UIFont(name: TPPConfiguration.ekirjastoFontName(), size: setFontSize) ?? UIFont.systemFont(ofSize: setFontSize)
       return font
     // Apply system font size adjustment to the given size
@@ -183,7 +178,6 @@ extension UIFont {
     if fontSizeAdjusted {
       // Apply user font size adjustment to the given font size
       setFontSize = fontSize * fontMultiplier
-      //print("Adjusted size: \(setFontSize), multiplier: \(fontMultiplier) in boldPalace")
       let font = UIFont(name: TPPConfiguration.ekirjastoFontName(), size: setFontSize) ?? UIFont.systemFont(ofSize: setFontSize)
       return font
     // Apply system font size adjustment to the given size

--- a/Palace/Fonts/Ekirjasto/UIFont+Ekirjasto.swift
+++ b/Palace/Fonts/Ekirjasto/UIFont+Ekirjasto.swift
@@ -123,7 +123,6 @@ extension UIFont {
       return font
     // Apply system font size adjustment to the given size
     } else {
-      print("Using system font size")
       let font = UIFont(name: TPPConfiguration.ekirjastoFontName(), size: fontSize) ?? UIFont.systemFont(ofSize: fontSize)
       return UIFontMetrics.default.scaledFont(for: font)
     }
@@ -151,7 +150,6 @@ extension UIFont {
       return font
     // Apply system font size adjustment to the given size
     } else {
-      print("Using system font size")
       let font = UIFont(name: TPPConfiguration.ekirjastoFontName(), size: fontSize) ?? UIFont.systemFont(ofSize: fontSize)
       return UIFontMetrics.default.scaledFont(for: font)
     }

--- a/Palace/Fonts/Ekirjasto/UIFont+Ekirjasto.swift
+++ b/Palace/Fonts/Ekirjasto/UIFont+Ekirjasto.swift
@@ -35,7 +35,7 @@ extension UIFont {
       let baseFontSize = UIFont.preferredFont(forTextStyle: textStyle).pointSize
       let setFontSize: CGFloat
       setFontSize = baseFontSize * fontMultiplier
-      print("Adjusted size: \(setFontSize), multiplier: \(fontMultiplier) in PalaceFont")
+      //print("Adjusted size: \(setFontSize), multiplier: \(fontMultiplier) in PalaceFont")
       let font = UIFont(name: TPPConfiguration.ekirjastoFontName(), size: setFontSize) ?? UIFont.systemFont(ofSize: setFontSize, weight: weight)
       return font
       // Apply system font size adjustment to the given size
@@ -62,7 +62,7 @@ extension UIFont {
       let baseFontSize = UIFont.preferredFont(forTextStyle: textStyle).pointSize
       let setFontSize: CGFloat
       setFontSize = baseFontSize * fontMultiplier
-      print("Adjusted size: \(setFontSize), multiplier: \(fontMultiplier) in semiBoldPalaceFont")
+      //print("Adjusted size: \(setFontSize), multiplier: \(fontMultiplier) in semiBoldPalaceFont")
       let font = UIFont(name: TPPConfiguration.ekirjastoFontName(), size: setFontSize) ?? UIFont.systemFont(ofSize: setFontSize, weight: weight)
       return font
       // Apply system font size adjustment to the given size
@@ -89,7 +89,7 @@ extension UIFont {
       let baseFontSize = UIFont.preferredFont(forTextStyle: textStyle).pointSize
       let setFontSize: CGFloat
       setFontSize = baseFontSize * fontMultiplier
-      print("Adjusted size: \(setFontSize), multiplier: \(fontMultiplier) in boldPalaceFont")
+      //print("Adjusted size: \(setFontSize), multiplier: \(fontMultiplier) in boldPalaceFont")
       let font = UIFont(name: TPPConfiguration.ekirjastoFontName(), size: setFontSize) ?? UIFont.systemFont(ofSize: setFontSize, weight: weight)
       return font
       // Apply system font size adjustment to the given size
@@ -125,7 +125,7 @@ extension UIFont {
     if fontSizeAdjusted {
       // Apply user font size adjustment to the given font size
       setFontSize = fontSize * fontMultiplier
-      print("Adjusted size: \(setFontSize), multiplier: \(fontMultiplier) in palaceFont")
+      //print("Adjusted size: \(setFontSize), multiplier: \(fontMultiplier) in palaceFont")
       let font = UIFont(name: TPPConfiguration.ekirjastoFontName(), size: setFontSize) ?? UIFont.systemFont(ofSize: setFontSize)
       return font
     // Apply system font size adjustment to the given size
@@ -154,7 +154,7 @@ extension UIFont {
     if fontSizeAdjusted {
       // Apply user font size adjustment to the given font size
       setFontSize = fontSize * fontMultiplier
-      print("Adjusted size: \(setFontSize), multiplier: \(fontMultiplier) in semiBoldPalace")
+      //print("Adjusted size: \(setFontSize), multiplier: \(fontMultiplier) in semiBoldPalace")
       let font = UIFont(name: TPPConfiguration.ekirjastoFontName(), size: setFontSize) ?? UIFont.systemFont(ofSize: setFontSize)
       return font
     // Apply system font size adjustment to the given size
@@ -183,7 +183,7 @@ extension UIFont {
     if fontSizeAdjusted {
       // Apply user font size adjustment to the given font size
       setFontSize = fontSize * fontMultiplier
-      print("Adjusted size: \(setFontSize), multiplier: \(fontMultiplier) in boldPalace")
+      //print("Adjusted size: \(setFontSize), multiplier: \(fontMultiplier) in boldPalace")
       let font = UIFont(name: TPPConfiguration.ekirjastoFontName(), size: setFontSize) ?? UIFont.systemFont(ofSize: setFontSize)
       return font
     // Apply system font size adjustment to the given size

--- a/Palace/Fonts/Ekirjasto/UIFont+Ekirjasto.swift
+++ b/Palace/Fonts/Ekirjasto/UIFont+Ekirjasto.swift
@@ -39,7 +39,6 @@ extension UIFont {
       return font
       // Apply system font size adjustment to the given size
     } else {
-      print("Using system font size")
       let font = UIFont(name: TPPConfiguration.ekirjastoFontName(), size: UIFont.preferredFont(forTextStyle: textStyle).pointSize) ?? UIFont.systemFont(ofSize: UIFont.preferredFont(forTextStyle: textStyle).pointSize, weight: weight)
       return UIFontMetrics.default.scaledFont(for: font)
     }
@@ -65,7 +64,6 @@ extension UIFont {
       return font
       // Apply system font size adjustment to the given size
     } else {
-      print("Using system font size")
       let font = UIFont(name: TPPConfiguration.ekirjastoFontName(), size: UIFont.preferredFont(forTextStyle: textStyle).pointSize) ?? UIFont.systemFont(ofSize: UIFont.preferredFont(forTextStyle: textStyle).pointSize, weight: weight)
       return UIFontMetrics.default.scaledFont(for: font)
     }
@@ -91,7 +89,6 @@ extension UIFont {
       return font
       // Apply system font size adjustment to the given size
     } else {
-      print("Using system font size")
       let font = UIFont(name: TPPConfiguration.ekirjastoFontName(), size: UIFont.preferredFont(forTextStyle: textStyle).pointSize) ?? UIFont.systemFont(ofSize: UIFont.preferredFont(forTextStyle: textStyle).pointSize, weight: weight)
       return UIFontMetrics.default.scaledFont(for: font)
     }
@@ -182,7 +179,6 @@ extension UIFont {
       return font
     // Apply system font size adjustment to the given size
     } else {
-      print("Using system font size")
       let font = UIFont(name: TPPConfiguration.ekirjastoFontName(), size: fontSize) ?? UIFont.systemFont(ofSize: fontSize)
       return UIFontMetrics.default.scaledFont(for: font)
     }

--- a/Palace/Network/TPPNetworkExecutor.swift
+++ b/Palace/Network/TPPNetworkExecutor.swift
@@ -66,7 +66,7 @@ enum NYPLResult<SuccessInfo> {
            useTokenIfAvailable: Bool = true,
            completion: @escaping (_ result: NYPLResult<Data>) -> Void) {
     //Print where we are making the get request to
-    ATLog(.debug, String(describing: reqURL.absoluteString))
+    print("GET:", reqURL.absoluteString)
     let req = request(for: reqURL, useTokenIfAvailable: useTokenIfAvailable)
     executeRequest(req, completion: completion)
   }
@@ -168,7 +168,7 @@ extension TPPNetworkExecutor: TPPRequestExecuting {
   ///   - completion: Always called when the resource is either fetched from
     //If we use Ekirjasto as our authentication definition, execute this
     if let authDefinition = TPPUserAccount.sharedAccount().authDefinition, authDefinition.isEkirjasto {
-      ATLog(.debug, "Ekirjasto execution")
+      print("Ekirjasto execution")
       //If there is a token, execute request with the token
       executeRequestWithToken(req, completion: completion)
       }
@@ -368,7 +368,7 @@ extension TPPNetworkExecutor {
     var req = request(for: reqURL)
     req.httpMethod = "PUT"
     //Print where we are making the PUT request to
-    ATLog(.debug, String(describing: reqURL.absoluteString))
+    print("PUT:", reqURL.absoluteString)
     let completionWrapper: (_ result: NYPLResult<Data>) -> Void = { result in
       switch result {
       case let .success(data, response): completion(data, response, nil)

--- a/Palace/Network/TPPNetworkExecutor.swift
+++ b/Palace/Network/TPPNetworkExecutor.swift
@@ -65,6 +65,8 @@ enum NYPLResult<SuccessInfo> {
   func GET(_ reqURL: URL,
            useTokenIfAvailable: Bool = true,
            completion: @escaping (_ result: NYPLResult<Data>) -> Void) {
+    //Print where we are making the get request to
+    ATLog(.debug, String(describing: reqURL.absoluteString))
     let req = request(for: reqURL, useTokenIfAvailable: useTokenIfAvailable)
     executeRequest(req, completion: completion)
   }
@@ -78,18 +80,26 @@ extension TPPNetworkExecutor: TPPRequestExecuting {
      return performDataTask(with: req) { result in
       switch result{
       case .failure(let error, let response):
+        //if this is the second 401, just complete so there is no endless refreshing
         if req.hasRetried {
           completion(result)
         }else{
           var updatedRequest = req
           updatedRequest.hasRetried = true
           if let httpResponse = response as? HTTPURLResponse {
+            // if 401, attempt to refresh token and rerun request
             if httpResponse.statusCode == 401 {
+              
+              //401 leads here
+              //Here it should trigger tokenrefresh if it's the first time.
+              //Next handle authenticateWithToken options 401, needs to log in, 200, token refreshed
               self.authenticateWithToken(TPPUserAccount.sharedAccount().authToken!) { status in
                 if status == 401 {
                   // User needs to login again, remove user's credentials.
                   TPPUserAccount.sharedAccount().removeAll()
                   
+
+                  //Show login page, and after login attempt the previous behaviour with the new token
                   EkirjastoLoginViewController.show {
                     if let token = TPPUserAccount.sharedAccount().authToken {
                       updatedRequest.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
@@ -100,7 +110,7 @@ extension TPPNetworkExecutor: TPPRequestExecuting {
 
                   }
                 }else if status == 200 {
-
+                  //If refresh is successful, execute the request again with new token
                   if let token = TPPUserAccount.sharedAccount().authToken {
                     updatedRequest.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
                     self.executeRequestWithToken(updatedRequest, completion: completion)
@@ -120,6 +130,7 @@ extension TPPNetworkExecutor: TPPRequestExecuting {
         }
 
       case .success(_, _):
+        //Goes here normally when the token is still good
         completion(result)
       }
     }
@@ -154,10 +165,17 @@ extension TPPNetworkExecutor: TPPRequestExecuting {
   @discardableResult
   func executeRequest(_ req: URLRequest, completion: @escaping (_: NYPLResult<Data>) -> Void) -> URLSessionDataTask {
     var resultTask: URLSessionDataTask?
-    
-    if let authDefinition = TPPUserAccount.sharedAccount().authDefinition, authDefinition.isSaml {
+  ///   - completion: Always called when the resource is either fetched from
+    //If we use Ekirjasto as our authentication definition, execute this
+    if let authDefinition = TPPUserAccount.sharedAccount().authDefinition, authDefinition.isEkirjasto {
+      ATLog(.debug, "Ekirjasto execution")
+      //If there is a token, execute request with the token
+      executeRequestWithToken(req, completion: completion)
+      }
+     else if let authDefinition = TPPUserAccount.sharedAccount().authDefinition, authDefinition.isSaml {
       resultTask = performDataTask(with: req, completion: completion)
     } else if !TPPUserAccount.sharedAccount().authTokenHasExpired && req.isTokenAuthorized && TPPUserAccount.sharedAccount().authTokenExpirationDate == nil {
+      //Goes here if there is no isEkirjasto definition
       executeRequestWithToken(req, completion: completion)
     } else if !TPPUserAccount.sharedAccount().authTokenHasExpired || !req.isTokenAuthorized || req.hasRetried {
       if req.hasRetried {
@@ -349,6 +367,8 @@ extension TPPNetworkExecutor {
                  completion: @escaping (_ result: Data?, _ response: URLResponse?,  _ error: Error?) -> Void) -> URLSessionDataTask {
     var req = request(for: reqURL)
     req.httpMethod = "PUT"
+    //Print where we are making the PUT request to
+    ATLog(.debug, String(describing: reqURL.absoluteString))
     let completionWrapper: (_ result: NYPLResult<Data>) -> Void = { result in
       switch result {
       case let .success(data, response): completion(data, response, nil)
@@ -450,37 +470,49 @@ extension TPPNetworkExecutor {
       }
     }
   }
-
+  
+  /// Performs a POST request to authentication to request a new token
+  /// - Parameters:
+  ///   - token: The possibly expired token used in the header
+  ///   - completion: Always called when the api call either returns or times out
   func authenticateWithToken(_ token: String, completion: ((Int?)->Void)? = nil){
+    //Get the only account we have, ekirjasto
     var currentAccount = AccountsManager.shared.currentAccount
     if currentAccount?.authenticationDocument == nil {
       currentAccount = AccountsManager.shared.accounts().first
     }
+    //Get the auth document and from it the authentication URL
     let authenticationDocument = currentAccount?.authenticationDocument
     let authentication = authenticationDocument?.authentication?.first(where: { $0.type == "http://e-kirjasto.fi/authtype/ekirjasto"})
     
     let link = authentication?.links?.first(where: {$0.rel == "authenticate"})
+    //Make a post request to the authentication URL
     var request = URLRequest(url: URL(string:link!.href)!)
     request.httpMethod = "POST"
+    
+    //Prints the token
     print("token \(token)")
+    //Set the token into the header as bearer
     request.setValue(
       "Bearer \(token)",
       forHTTPHeaderField: "Authorization"
     )
-    print("access token \(token)")
+    
+    //Run the POST request and handle response
     URLSession.shared.dataTask(with: request){ data, response, error in
       
+      //If there is data, get from it the access token and patronPermanent ID
       if(data != nil){
         do {
           if let json = try JSONSerialization.jsonObject(with: data!, options: []) as? [String: Any] {
             let sharedAccount = TPPUserAccount.sharedAccount()
             
                 if let accessToken = json["access_token"] as? String {
-                    print("ACCESS TOKEN \(accessToken)")
+                    print("ACCESS TOKEN \(accessToken)") //NEW TOKEN
                     sharedAccount.setAuthToken(accessToken,barcode: nil, pin: nil, expirationDate: nil)
 
                 }
-                if let patronInfo = json["patron_info"] as? String {
+                if let patronInfo = json["patron_info"] as? String { //PATRON INFO
                     if let patronData = patronInfo.data(using: .utf8) {
                         if let patronObject = try JSONSerialization.jsonObject(with: patronData, options: []) as? [String: Any] {
                             if let patronPermanentId = patronObject["permanent_id"] as? String {
@@ -490,6 +522,7 @@ extension TPPNetworkExecutor {
                         }
                     }
                 }
+            //If correct answer, login successful and we notify about the login
             TPPSignInBusinessLogic.getShared { logic in
                       logic?.notifySignIn()
               }
@@ -500,6 +533,7 @@ extension TPPNetworkExecutor {
         }
 
       } else {
+        //If answer is anything else than 200 with the token data, log user out
         TPPSignInBusinessLogic.getShared { logic in
           DispatchQueue.main.async {
           logic?.performLogOut()
@@ -526,7 +560,7 @@ extension TPPNetworkExecutor {
   func revokeToken(_ sessionId: String? = nil){
     
   }
-  
+  /// Refresh token with username and password
   func executeTokenRefresh(username: String, password: String, completion: @escaping (Result<TokenResponse, Error>) -> Void) {
     let account = TPPUserAccount.sharedAccount()
     guard let tokenURL = TPPUserAccount.sharedAccount().authDefinition?.tokenURL else {

--- a/Palace/Network/TPPNetworkExecutor.swift
+++ b/Palace/Network/TPPNetworkExecutor.swift
@@ -506,13 +506,13 @@ extension TPPNetworkExecutor {
         do {
           if let json = try JSONSerialization.jsonObject(with: data!, options: []) as? [String: Any] {
             let sharedAccount = TPPUserAccount.sharedAccount()
-            
+            //Get accessToken from the data and set it to the account
                 if let accessToken = json["access_token"] as? String {
-                    print("ACCESS TOKEN \(accessToken)") //NEW TOKEN
+                    print("ACCESS TOKEN \(accessToken)")
                     sharedAccount.setAuthToken(accessToken,barcode: nil, pin: nil, expirationDate: nil)
-
                 }
-                if let patronInfo = json["patron_info"] as? String { //PATRON INFO
+            //Get permanent id from patron info and set it to the account
+                if let patronInfo = json["patron_info"] as? String {
                     if let patronData = patronInfo.data(using: .utf8) {
                         if let patronObject = try JSONSerialization.jsonObject(with: patronData, options: []) as? [String: Any] {
                             if let patronPermanentId = patronObject["permanent_id"] as? String {


### PR DESCRIPTION
**What's this do?**
Added a missing Ekirjasto authType, that does not affect the functioning of anything, but can be used later to personify behavior for Ekirjasto authentication if needed. Added authType check to the network requests, but it still behaved like before.

Removed some old prints that flooded the logs.

Commented code around the networking, now prints where we send get and put requests. Also wrote comments for the recursive function that is run on every request, for clarifying the functioning.

Also tested the handling of 401 responses, and all seems to go okay. Refresh was checked to be handled correctly on magazine opening, book loan and book return. If refresh is not successful, the login page is shown.

**Why are we doing this? (w/ Notion link if applicable)**
We had a lot of 401 errors at some point, that would suggest refreshes not working. But they have lessened, and I can not reproduce the behavior, Jira ticket is vague too.

https://jira.it.helsinki.fi/browse/EKIRJASTO-111

**How should this be tested? / Do these changes have associated tests?**
[Description of any tests that need to be performed once merged goes here]
No changes that affect behavior, but just in case, should test by logging in, and loaning something, logs should shoe text "Ekirjasto execution".

**Did someone actually run this code to verify it works?**
Ran on emulator.

**Have the Transifex translators been notified?**
No changes.
