### PR TITLE
Ekir 332 sdk update

### DIFF
--- a/.github/workflows/ios-main.yml
+++ b/.github/workflows/ios-main.yml
@@ -17,7 +17,7 @@ env:
 
 jobs:
   build:
-    runs-on: macOS-13
+    runs-on: macOS-15
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -34,8 +34,8 @@ jobs:
           private-key-name: ekirjasto-ci-ed25519
           private-key: ${{ secrets.SSH_PRIVATE_KEY }}
           host: github.com
-      - name: Force Xcode 15
-        run: sudo xcode-select -switch /Applications/Xcode_15.0.1.app
+      - name: Force Xcode 16
+        run: sudo xcode-select -switch /Applications/Xcode_16.2.app
 
       - name: Bootstrap (and reveal secrets)
         env:

--- a/.github/workflows/ios-pr.yml
+++ b/.github/workflows/ios-pr.yml
@@ -17,7 +17,7 @@ env:
 
 jobs:
   build:
-    runs-on: macOS-13
+    runs-on: macOS-15
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -34,8 +34,8 @@ jobs:
           private-key-name: ekirjasto-ci-ed25519
           private-key: ${{ secrets.SSH_PRIVATE_KEY }}
           host: github.com
-      - name: Force Xcode 15
-        run: sudo xcode-select -switch /Applications/Xcode_15.0.1.app
+      - name: Force Xcode 16
+        run: sudo xcode-select -switch /Applications/Xcode_16.2.app
 
       - name: Bootstrap (and reveal secrets)
         env:

--- a/.github/workflows/ios-release.yml
+++ b/.github/workflows/ios-release.yml
@@ -17,7 +17,7 @@ env:
 
 jobs:
   build:
-    runs-on: macOS-13
+    runs-on: macOS-15
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -34,8 +34,8 @@ jobs:
           private-key-name: ekirjasto-ci-ed25519
           private-key: ${{ secrets.SSH_PRIVATE_KEY }}
           host: github.com
-      - name: Force Xcode 15
-        run: sudo xcode-select -switch /Applications/Xcode_15.0.1.app
+      - name: Force Xcode 16
+        run: sudo xcode-select -switch /Applications/Xcode_16.2.app
 
       - name: Bootstrap (and reveal secrets)
         env:

--- a/Palace.xcodeproj/project.pbxproj
+++ b/Palace.xcodeproj/project.pbxproj
@@ -4322,7 +4322,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "/usr/local/bin/carthage copy-frameworks\n";
+			shellScript = "/opt/homebrew/bin/carthage copy-frameworks\n";
 		};
 		331264662A287F53006BA87D /* Crashlytics */ = {
 			isa = PBXShellScriptBuildPhase;

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -59,7 +59,7 @@ platform :ios do
   lane :test do
     run_tests(
       project: "Palace.xcodeproj",
-      devices: ["iPhone 12 Pro"], # TODO:SAMI: Change to iPhone 15 Pro?
+      devices: ["iPhone 15 Pro"], 
       scheme: "Ekirjasto"
     )
   end

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -60,7 +60,8 @@ platform :ios do
     run_tests(
       project: "Palace.xcodeproj",
       devices: ["iPhone 15 Pro"], 
-      scheme: "Ekirjasto"
+      scheme: "Ekirjasto",
+      xcargs: 'EXCLUDED_ARCHS[sdk=iphonesimulator*]=x86_64',
     )
   end
   


### PR DESCRIPTION
### What: ###
This pull request includes several updates to the iOS build and testing workflows, as well as minor configuration changes to the project. The most significant changes include upgrading the macOS and Xcode versions used in CI workflows, updating the Carthage path, modifying the test device and build arguments in the `Fastfile`, and updating a submodule reference.

### CI Workflow Updates:
* Updated the `runs-on` configuration in `.github/workflows/ios-main.yml`, `.github/workflows/ios-pr.yml`, and `.github/workflows/ios-release.yml` to use `macOS-15` instead of `macOS-13`. [[1]](diffhunk://#diff-912a9fc735c436b3411ce52b7ccb1829cdff5532a80072ccdb77bb1b1ca33d84L20-R20) [[2]](diffhunk://#diff-7f5fd047c6bc1909b0293546c17b96f5ae3eb4b653000ca78fb41b1019d5c487L20-R20) [[3]](diffhunk://#diff-4b7cd12057679e964ecd3635db894e799a1c04e845628673c21ca95ad6563a84L20-R20)
* Updated the Xcode version in the same workflow files to use Xcode 16.2 instead of Xcode 15.0.1. [[1]](diffhunk://#diff-912a9fc735c436b3411ce52b7ccb1829cdff5532a80072ccdb77bb1b1ca33d84L37-R38) [[2]](diffhunk://#diff-7f5fd047c6bc1909b0293546c17b96f5ae3eb4b653000ca78fb41b1019d5c487L37-R38) [[3]](diffhunk://#diff-4b7cd12057679e964ecd3635db894e799a1c04e845628673c21ca95ad6563a84L37-R38)

### Build Configuration:
* Changed the Carthage path in `Palace.xcodeproj/project.pbxproj` from `/usr/local/bin/carthage` to `/opt/homebrew/bin/carthage`.

### Test Configuration:
* Updated the test device in `fastlane/Fastfile` from "iPhone 12 Pro" to "iPhone 15 Pro" and added `EXCLUDED_ARCHS` build arguments to exclude the `x86_64` architecture for iPhone simulators.

### Submodule Update:
* Updated the `ios-audiobooktoolkit` submodule reference to a new commit (`c125d92220ada20dc4373b200ce2c93f0302fc96`).