### PR TITLE
EKIRJASTO-425 Localize loans and holds tab strings

### DIFF
--- a/Palace/MyBooks/Views/LoansAndHolds/LoansAndHoldsView.swift
+++ b/Palace/MyBooks/Views/LoansAndHolds/LoansAndHoldsView.swift
@@ -61,8 +61,13 @@ struct LoansAndHoldsView: View {
         "View list of books on loan or list of books on hold",
         selection: $selectedSubview
       ) {
+        //Add the localized title for the holds and loans buttons
         ForEach(subviews, id: \.self) {
-          Text($0)
+          if($0 == "Loans") {
+            Text(Strings.MyBooksView.loansNavTitle)
+          } else {
+            Text(Strings.MyBooksView.holdsNavTitle)
+          }
         }
       }
       .pickerStyle(.segmented)

--- a/Palace/Utilities/Localization/Strings.swift
+++ b/Palace/Utilities/Localization/Strings.swift
@@ -284,6 +284,8 @@ struct Strings {
   struct MyBooksView {
     static let loansAndHoldsNavTitle = NSLocalizedString("My Books", comment: "Tab title for loans and holds view")
     static let favoritesAndReadNavTitle = NSLocalizedString("Favorites", comment: "Tab title for favorites and read books view")
+    static let loansNavTitle = NSLocalizedString("Loans", comment: "Tab title for loans view")
+    static let holdsNavTitle = NSLocalizedString("Holds", comment: "Tab title for holds view")
     static let sortBy = NSLocalizedString("Sort By:", comment: "")
     static let searchBooks = NSLocalizedString("Search My Books", comment: "")
     static let emptyViewMessage = NSLocalizedString("Visit the Catalog to\nadd books to My Books.", comment: "")


### PR DESCRIPTION
**What's this do?**
Add localizations to loans and holds tabs.

**Why are we doing this? (w/ Notion link if applicable)**
The tabs were not localized.

https://jira.it.helsinki.fi/browse/EKIRJASTO-425

**How should this be tested? / Do these changes have associated tests?**
If you can change your device language, the loans and holds tabs should be seen as untranslated strings.

**Did someone actually run this code to verify it works?**
Tested on emulator.

**Have the Transifex translators been notified?**
- [x] Informed translators