### PR TITLE
EKIRJASTO-441 Display audiobook duration more clearly

### DIFF
--- a/Palace/Book/UI/BookDetailView/TPPBookDetailView.m
+++ b/Palace/Book/UI/BookDetailView/TPPBookDetailView.m
@@ -444,6 +444,8 @@ static NSString *DetailHTMLTemplate = nil;
   NSString *const accessibilityFeaturesValueString = [NSString stringWithFormat:@"%@",NSLocalizedString(@"Not yet available", nil)];
   NSString *const accessibilitySummaryValueString = [NSString stringWithFormat:@"%@",NSLocalizedString(@"Not yet available", nil)];
   
+  NSString *const bookDurationValueString = [self displayStringForDuration: self.book.bookDuration];
+  
   if (!categoriesValueString && !publishedValueString && !publisherValueString && !self.book.distributor) {
     self.topFootnoteSeparater.hidden = YES;
     self.bottomFootnoteSeparator.hidden = YES;
@@ -481,7 +483,7 @@ static NSString *DetailHTMLTemplate = nil;
   self.accessModeLabelValue = [self createFooterLabelWithString:accessModeValueString alignment:NSTextAlignmentRight];
   self.accessibilityFeaturesLabelValue = [self createFooterLabelWithString:accessibilityFeaturesValueString alignment:NSTextAlignmentRight];
   self.accessibilitySummaryLabelValue = [self createFooterLabelWithString:accessibilitySummaryValueString alignment:NSTextAlignmentRight];
-  self.bookDurationLabelValue = [self createFooterLabelWithString:[self displayStringForDuration: self.book.bookDuration] alignment:NSTextAlignmentLeft];
+  self.bookDurationLabelValue = [self createFooterLabelWithString:bookDurationValueString alignment:NSTextAlignmentLeft];
   self.narratorsLabelValue.numberOfLines = 0;
 
   self.topFootnoteSeparater = [[UIView alloc] init];
@@ -508,11 +510,34 @@ static NSString *DetailHTMLTemplate = nil;
   return label;
 }
 
+  // Returns the book's duration as a localized string, formatted from its total duration in seconds.
 - (NSString *) displayStringForDuration: (NSString *) durationInSeconds {
   double totalSeconds = [durationInSeconds doubleValue];
+  
   int hours = (int)(totalSeconds / 3600);
   int minutes = (int)((totalSeconds - (hours * 3600)) / 60);
-  return [NSString stringWithFormat:@"%d hours, %d minutes", hours, minutes];
+  
+  NSString *hoursAsString = [NSString stringWithFormat:@"%d", hours];
+  NSString *minutesAsString = [NSString stringWithFormat:@"%d", minutes];
+  
+  // Checks whether to use the singular form instead of the plural (hour or hours, minute or minutes)
+  // and then formats the hour and minute units accordingly
+  NSString *hourTimeUnit = hours == 1 ? NSLocalizedString(@"hour", nil) : NSLocalizedString(@"hours", nil);
+  NSString *minuteTimeUnit = minutes == 1 ? NSLocalizedString(@"minute", nil) : NSLocalizedString(@"minutes", nil);
+  
+  NSString *durationAsString;
+  
+  if (hours > 0) {
+    // Always show minutes if the book is at least 1 hour long (even if it is just 1 hour, 0 minutes)
+    // Examples: "3 hours, 33 minutes" "1 hour, 33 minutes" "1 hour, 1 minute"
+    durationAsString = [NSString stringWithFormat:@"%@ %@, %@ %@", hoursAsString, hourTimeUnit, minutesAsString, minuteTimeUnit];
+  } else {
+    // but if the book is less than an hour long, only show the minutes (don't show zero hours)
+    // Example: "33 minutes" "1 minute"
+    durationAsString = [NSString stringWithFormat:@"%@ %@", minutesAsString, minuteTimeUnit];
+  }
+  
+  return durationAsString;
 }
 
 - (void)setupAutolayoutConstraints

--- a/Palace/Utilities/Localization/Strings.swift
+++ b/Palace/Utilities/Localization/Strings.swift
@@ -344,4 +344,14 @@ struct Strings {
     static let borrowFailedMessage = NSLocalizedString("Borrowing %@ could not be completed.", comment: "")
     static let loanAlreadyExistsAlertMessage = NSLocalizedString("You have already checked out this loan. You may need to refresh your My Books list to download the title.", comment: "")
   }
+  
+  struct TimeAndDuration {
+    static let hour = NSLocalizedString("hour", comment: "Hour (in singular), used for example when audiobook duration is displayed for user, '1 hour'.")
+    static let hours = NSLocalizedString("hours", comment: "Hours (in plural), used for example when audiobook duration is displayed for user, '3 hours'.")
+    static let minute = NSLocalizedString("minute", comment: "Minute (in singular), used for example when audiobook duration is displayed for user, '1 minute'.")
+    static let minutes = NSLocalizedString("minutes", comment: "Minutes (in plural), used for example when audiobook duration is displayed for user, '3 minutes'.")
+    static let second = NSLocalizedString("second", comment: "Second (in singular), used for example when audiobook duration is displayed for user, '1 second'.")
+    static let seconds = NSLocalizedString("seconds", comment: "Seconds (in plural), used for example when audiobook duration is displayed for user, '3 seconds'.")
+  }
+    
 }


### PR DESCRIPTION
## What's this do?
- Formats and translates audiobook duration in the book detail view
   - if the audiobook duration is less than an hour, only minutes are displayed
   - otherwise the duration is displayed in hours and minutes

### Why are we doing this?
- The duration of an audiobook is important information for users and should be clearly stated
- https://jira.it.helsinki.fi/browse/EKIRJASTO-441

### How should this be tested?
- Check book detail view in app and confirm that the duration is correctly displayed

### Did someone actually run this code to verify it works?
- Tested with simulator and device

### Have the Transifex translators been notified?
- [ ] New strings translated in Transifex
