### PR TITLE
set timeouts/retries

### DIFF
--- a/scripts/fastlane.sh
+++ b/scripts/fastlane.sh
@@ -19,6 +19,8 @@ fatal() {
 # Set some environment variables to make Fastlane work smoothly
 export LC_ALL="en_US.UTF-8"
 export LANG="en_US.UTF-8"
+export FASTLANE_XCODEBUILD_SETTINGS_TIMEOUT=60
+export FASTLANE_XCODEBUILD_SETTINGS_RETRIES=10
 
 if command -v bundle > /dev/null 2>&1; then
   bundle install || exit $?


### PR DESCRIPTION
Add timeout env variables to `scripts/fastlane.sh` 
* [`scripts/fastlane.sh`](diffhunk://#diff-9ff5d414ac7dc5fd95742ce9dd29d34d556dd7b3b0d785318d59deb89b0f0f55R22-R23): Added `FASTLANE_XCODEBUILD_SETTINGS_TIMEOUT` and `FASTLANE_XCODEBUILD_SETTINGS_RETRIES` environment variables to configure timeout and retry settings for Xcode build settings in Fastlane.