### PR TITLE
EKIRJASTO-29 Book detail view updates for iPad

### DIFF
--- a/Palace/Book/UI/BookButtons/TPPBookButtonsView.m
+++ b/Palace/Book/UI/BookButtons/TPPBookButtonsView.m
@@ -126,7 +126,7 @@
   [self.constraints removeAllObjects];
 
   int buttonsViewWidth = self.bounds.size.width;
-  double iPadButtonsViewMaxWidth = 540.0;
+  double iPadButtonsViewMaxWidth = 704.0; // for comparison with default value
   int numberOfButtons = (int)self.visibleButtons.count;
   double buttonOffset = 6.0;
   TPPRoundedButton *previousButton = nil;

--- a/Palace/Book/UI/BookDetailView/TPPBookDetailView.m
+++ b/Palace/Book/UI/BookDetailView/TPPBookDetailView.m
@@ -196,6 +196,7 @@ static NSString *DetailHTMLTemplate = nil;
      [[TPPRootTabBarController sharedController] traitCollection].horizontalSizeClass != UIUserInterfaceSizeClassCompact) {
     self.closeButton = [UIButton buttonWithType:UIButtonTypeSystem];
     [self.closeButton setTitle:NSLocalizedString(@"Close", nil) forState:UIControlStateNormal];
+    self.closeButton.titleLabel.font = [UIFont palaceFontOfSize:20];
     [self.closeButton setTitleColor:[TPPConfiguration mainColor] forState:UIControlStateNormal];
     [self.closeButton setContentHorizontalAlignment:UIControlContentHorizontalAlignmentRight];
     [self.closeButton setContentEdgeInsets:UIEdgeInsetsMake(0, 2, 0, 0)];
@@ -788,7 +789,7 @@ static NSString *DetailHTMLTemplate = nil;
   if (self.closeButton) {
     [self.closeButton autoPinEdgeToSuperviewMargin:ALEdgeTrailing];
     [self.closeButton autoPinEdge:ALEdgeTop toEdge:ALEdgeTop ofView:self.titleLabel];
-    [self.closeButton autoSetDimension:ALDimensionWidth toSize:80 relation:NSLayoutRelationLessThanOrEqual];
+    [self.closeButton autoSetDimension:ALDimensionWidth toSize:100 relation:NSLayoutRelationLessThanOrEqual];
     [NSLayoutConstraint deactivateConstraints:@[selectionButtonConstraint]];
     [self.closeButton autoPinEdge:ALEdgeLeading toEdge:ALEdgeTrailing ofView:self.titleLabel withOffset:MainTextPaddingLeft];
     [self.closeButton setContentCompressionResistancePriority:UILayoutPriorityRequired forAxis:UILayoutConstraintAxisHorizontal];

--- a/Palace/Book/UI/BookDetailView/TPPBookDetailViewController.m
+++ b/Palace/Book/UI/BookDetailView/TPPBookDetailViewController.m
@@ -58,7 +58,7 @@
 
   if(UIDevice.currentDevice.userInterfaceIdiom == UIUserInterfaceIdiomPad &&
      [[TPPRootTabBarController sharedController] traitCollection].horizontalSizeClass != UIUserInterfaceSizeClassCompact) {
-    self.modalPresentationStyle = UIModalPresentationFormSheet;
+    self.modalPresentationStyle = UIModalPresentationPageSheet;
   }
 
   [[NSNotificationCenter defaultCenter] addObserver:self
@@ -246,7 +246,7 @@
     [viewController.navigationController pushViewController:self animated:YES];
   } else {
     UINavigationController *navVC = [[UINavigationController alloc] initWithRootViewController:self];
-    navVC.modalPresentationStyle = UIModalPresentationFormSheet;
+    navVC.modalPresentationStyle = UIModalPresentationPageSheet;
     [viewController presentViewController:navVC animated:YES completion:nil];
   }
 }
@@ -269,7 +269,7 @@
                                                                traitCollection:(UITraitCollection *)traitCollection
 {
   if (traitCollection.horizontalSizeClass == UIUserInterfaceSizeClassRegular) {
-    return UIModalPresentationFormSheet;
+    return UIModalPresentationPageSheet;
   } else {
     return UIModalPresentationNone;
   }

--- a/Palace/MyBooks/Views/LoansAndHolds/Loans/LoansView.swift
+++ b/Palace/MyBooks/Views/LoansAndHolds/Loans/LoansView.swift
@@ -9,6 +9,7 @@ struct LoansView: View {
 
   @ObservedObject var loansViewModel: LoansViewModel
   @State var showDetailForBook: TPPBook?
+  @Environment(\.horizontalSizeClass) var horizontalSizeClass
   let backgroundColor: Color = Color(TPPConfiguration.backgroundColor())
 
   var body: some View {
@@ -65,7 +66,7 @@ struct LoansView: View {
         if loansViewModel.userHasBooksOnLoan {
           // user is logged in and has books on loan
           // show list of lent books
-          BookListView
+          bookListView
             .refreshable {
               loansViewModel.reloadData()
             }
@@ -73,7 +74,7 @@ struct LoansView: View {
           VStack {
             // user is logged in and has no books on loan
             // show instructions how to borrow books
-            EmptyHoldsView
+            emptyLoansView
           }
           .frame(minHeight: geometry.size.height)
           .refreshable {
@@ -84,7 +85,7 @@ struct LoansView: View {
         VStack {
           // user has not logged in
           // remind user to log in to see the books on loan
-          LogInInstructionsView
+          logInInstructionsView
         }
         .frame(minHeight: geometry.size.height)
         .refreshable {
@@ -95,7 +96,7 @@ struct LoansView: View {
     }
   }
 
-  @ViewBuilder private var BookListView: some View {
+  @ViewBuilder private var bookListView: some View {
 
     AdaptableGridLayout {
 
@@ -113,7 +114,7 @@ struct LoansView: View {
 
   }
 
-  @ViewBuilder private var EmptyHoldsView: some View {
+  @ViewBuilder private var emptyLoansView: some View {
     Text(Strings.MyBooksView.loansEmptyViewMessage)
       .multilineTextAlignment(.center)
       .foregroundColor(.gray)
@@ -121,55 +122,92 @@ struct LoansView: View {
       .verticallyCentered()
   }
 
-  @ViewBuilder private var LogInInstructionsView: some View {
+  @ViewBuilder private var logInInstructionsView: some View {
     Text(Strings.MyBooksView.loansNotLoggedInViewMessage)
       .multilineTextAlignment(.center)
       .foregroundColor(.gray)
       .horizontallyCentered()
       .verticallyCentered()
   }
-
+  
   private func bookCell(for book: TPPBook) -> some View {
-
+    
     let bookCellModel = BookCellModel(book: book)
-
+    
     bookCellModel
-      .statePublisher.assign(to: \.isLoading, on: self.loansViewModel)
+      .statePublisher
+      .assign(to: \.isLoading, on: self.loansViewModel)
       .store(in: &self.loansViewModel.observers)
-
-    if self.loansViewModel.isPad {
-
-      return Button {
-        showDetailForBook = book
-      } label: {
-        BookCell(model: bookCellModel)
-      }
-      .sheet(item: $showDetailForBook) { item in
-        UIViewControllerWrapper(
-          TPPBookDetailViewController(book: item), updater: { _ in }
-        ).anyView()
-      }
-      .anyView()
-
+    
+    if self.loansViewModel.isPad && horizontalSizeClass == .regular {
+      // for iPads that have more horizontal space in view,
+      // create a button to open the book's book detail view as a modal sheet
+      return AnyView(bookDetailButton(book: book, model: bookCellModel))
     } else {
-
-      return NavigationLink(
-        destination: UIViewControllerWrapper(
-          TPPBookDetailViewController(book: book), updater: { _ in })
-      ) {
-        BookCell(model: bookCellModel)
-          .padding(.leading, -25)
-          .padding(.vertical, 15)
-          .border(width: 1, edges: [.bottom ], color: Color("ColorEkirjastoLightestGreen"))
-          .padding(.top, -25)
-          .padding(.bottom, 10)
-          .padding(.leading, 20)
-          .padding(.trailing, 10)
-      }
-      .anyView()
-
+      // for iPads with less horizontal space in view and all iPhones
+      // create navigation link to move to the book's book detail view in full view
+      return AnyView(bookDetailNavigationLink(book: book, model: bookCellModel))
     }
-
+    
+  }
+  
+  @ViewBuilder private func bookDetailButton(
+    book: TPPBook, model: BookCellModel
+  ) -> some View {
+    
+    Button {
+      // The action for this button. When button is clicked,
+      // the book parameter is set to showDetailForBook variable.
+      showDetailForBook = book
+    } label: {
+      // The appearance for the button is a BookCell view for this book.
+      BookCell(model: model)
+    }
+    // Opens a modal sheet with book's detail view as content.
+    .sheet(item: $showDetailForBook) { item in
+      bookDetailView(for: item)
+    }
+    
+  }
+  
+  @ViewBuilder private func bookDetailNavigationLink(
+    book: TPPBook, model: BookCellModel
+  ) -> some View {
+    
+    NavigationLink(destination: bookDetailView(for: book)) {
+      // Book cell for this book is a link. When cell is clicked,
+      // navigate to the book's detail view.
+      BookCell(model: model)
+        .padding(.leading, -25)
+        .padding(.vertical, 15)
+        .border(
+          width: 1,
+          edges: [.bottom],
+          color: Color("ColorEkirjastoLightestGreen")
+        )
+        .padding(.top, -25)
+        .padding(.bottom, 10)
+        .padding(.leading, 20)
+        .padding(.trailing, 10)
+    }
+    
+  }
+  
+  @ViewBuilder private func bookDetailView(for book: TPPBook) -> some View {
+    // Create a view that displays detailed information of the selected book
+    
+    if #available(iOS 18.0, *) {
+      // use bigger sheet (page size) for iOS 18 or higher
+      UIViewControllerWrapper(
+        TPPBookDetailViewController(book: book), updater: { _ in }
+      )
+      .presentationSizing(.page)
+    } else {
+      // for older iOS versions, bigger sheet (page size) is default
+      UIViewControllerWrapper(
+        TPPBookDetailViewController(book: book), updater: { _ in }
+      )
+    }
   }
 
   @ViewBuilder private var searchButton: some View {


### PR DESCRIPTION
### What's this do?
- User can see more of the individual book's details on the iPad without having to scroll the view
  - in full screen mode, the book details opens in a page sheet view
  - the book details view also adapts to the display space given to the application

### Why are we doing this?
- we are addressing the changes brought by iOS 18
- the book details view UI is now consistent across the app on iPads
- https://jira.it.helsinki.fi/browse/EKIRJASTO-29 

### How should this be tested?
- Open the book detail view
  - in full screen and different split view configurations
  - in portrait and in landscape
  - from Browse books view and from any of the My Books (=loans, holds or favorites) view

### Did someone actually run this code to verify it works?
- Tested with simulator
- Tested with device (iPad with iOS < 18)

