### PR TITLE
EKIRJASTO-444 Search bar and tab bar updates

### DIFF
--- a/Palace/AppInfrastructure/TPPRootTabBarController+Extensions.swift
+++ b/Palace/AppInfrastructure/TPPRootTabBarController+Extensions.swift
@@ -1,46 +1,44 @@
 //
 //  TPPRootTabBarController+Extensions.swift
 //
+//  Tab bar is the main navigation bar in app.
 
 import UIKit
 
 @objc extension TPPRootTabBarController {
-  
-  // Called when app user interface environment has changed
+
+  // Called when app user interface environment has changed.
   @objc(handleTraitCollectionChange:)  //<- objc name for the function
   func handleTraitCollectionChange(previousTraitCollection: UITraitCollection) {
-    
-    if appAppearanceHasChanged() {
-      printToConsole(.info, "App appearance was toggled")
-      handleUserInterfaceStyleChange()
-    }
-    
-    // other trait collection changes could also
-    // be checked and handled here
-    // besides the user interface change
-    
-    
-    // MARK: - Trait collection change handlers
-    
+
+    // Logging the current appearance and traits for development
+    // logCurrentAppAppearance()
+    // logCurrentDeviceTraits()
+
+    handleUserInterfaceStyleChange()
+
+    // MARK: - Functions to modify app appearance
+
     // User has switched between dark and light mode
     // which means that the user interface style has changed
     func handleUserInterfaceStyleChange() {
-      
-      // Logging the current appearance, just info for developer
-      logCurrentAppAppearance()
-      
-      // Always update the tab bar appearance after toggling
-      updateTabBarAppearance()
+
+      if appAppearanceHasChanged() {
+        printToConsole(.info, "App appearance was toggled")
+
+        // Always update the tab bar appearance after toggling
+        updateTabBarAppearance()
+      }
+
     }
-    
-    // MARK: - Helpers for app appearance (UI style change)
-    
-    
-    // Tab bar is the bottom navigation bar in app,
-    // currently only tab bar item icons need to be updated
+
+    // MARK: - Helpers for app appearance (UI style)
+
+    // This is a temporary fix that forces tab bar icons to update
+    // after toggling to device to dark mode and vice versa
     func updateTabBarAppearance() {
       printToConsole(.info, "Updating tab bar appearance")
-      
+
       // Mapping the tab bar item's index number with correct image set.
       // Needs to be updated if tabs, tab order, or the icon names ever change...
       let tabBarItemImages: [Int: (image: String, selectedImage: String)] = [
@@ -50,34 +48,39 @@ import UIKit
         3: ("Magazines", "MagazinesSelected"),
         4: ("Settings", "SettingsSelected"),
       ]
-      
+
       // Handle all the tabs in tab bar one by one
       for (index, tabBarItem) in self.tabBar.items!.enumerated() {
-        
+
         // Get the icon images for this tab bar item
         if let itemIcons = tabBarItemImages[index] {
-          
+
           // and set one icon for the tab when it's default icon is visible
           tabBarItem.image = UIImage(named: itemIcons.image)?.withRenderingMode(
             .alwaysOriginal)
-          
+
           // and another icon that appears when the tab is the selected tab
           tabBarItem.selectedImage = UIImage(named: itemIcons.selectedImage)?
             .withRenderingMode(.alwaysOriginal)
         }
-        
+
       }
-      
+
     }
-    
+
+    // MARK: - Boolean helpers
+
     // If the trait collection change concerns the UI style,
     // then app appearance has changed
     func appAppearanceHasChanged() -> Bool {
-      return self.traitCollection.userInterfaceStyle != previousTraitCollection.userInterfaceStyle
+      return self.traitCollection.userInterfaceStyle
+        != previousTraitCollection.userInterfaceStyle
     }
-    
+
+    // MARK: - Logging helpers
+
     // Possible appearance styles are light, dark and unspecified
-    func logCurrentAppAppearance() -> Void {
+    func logCurrentAppAppearance() {
       switch self.traitCollection.userInterfaceStyle {
         case .dark:
           printToConsole(.info, "App appearance set to dark mode")
@@ -85,10 +88,63 @@ import UIKit
           printToConsole(.info, "App appearance set to light mode")
         case .unspecified:
           printToConsole(.info, "App appearance set to unspecified mode")
-      }
-      
+        }
     }
-    
+
+    // Logs info about current device
+    func logCurrentDeviceTraits() {
+      logDeviceModel()
+      logDeviceSystemAndVersion()
+      logDeviceHorizontalSizeClass()
+      logDeviceInterfaceType()
+    }
+
+    // Logs iOS version, for example 18.5
+    func logDeviceSystemAndVersion() {
+      #if os(iOS)
+        printToConsole(.info, "Current device operating system: iOS")
+      #else
+        printToConsole(.info, "Current device operating system: not iOS")
+      #endif
+
+      printToConsole(.info, "Current device system version: \(UIDevice.current.systemVersion)")
+    }
+
+    // Logs name for the Apple device, such as iPhone or iPad
+    func logDeviceModel() {
+      printToConsole(.info, "Current device model: \(UIDevice.current.model)")
+    }
+
+    // Logs the horizontal space currently available to the app.
+    // Pads normally use regular, but can change to compact,
+    // for example if screen is split in iPad with other applications.
+    func logDeviceHorizontalSizeClass() {
+      switch self.traitCollection.horizontalSizeClass {
+      case .compact:
+        printToConsole(.info, "Current device horizontal size class: compact")
+      case .regular:
+        printToConsole(.info, "Current device horizontal size class: regular")
+      case .unspecified:
+        printToConsole(
+          .info, "Current device horizontal size class: unspecified")
+      }
+    }
+
+    // Logs the type of interface used, such as pad or phone
+    func logDeviceInterfaceType() {
+      switch UIDevice.current.userInterfaceIdiom {
+      case .pad:
+        printToConsole(.info, "Current device interface type: pad")
+      case .phone:
+        printToConsole(.info, "Current device interface type: phone")
+      default:
+        printToConsole(
+          .info,
+          "Current device interface type: mac, tv, vision, carPlay or unspecified"
+        )
+      }
+    }
+
   }
-  
+
 }

--- a/Palace/Catalog/Navigation/TPPCatalogNavigationController.m
+++ b/Palace/Catalog/Navigation/TPPCatalogNavigationController.m
@@ -42,6 +42,19 @@
                          initWithURL:urlToLoad];
   
   self.viewController.title = NSLocalizedString(@"Browse Books", nil);
+  
+  // Title label view is used to make sure that view's name remains visible,
+  // at the top of the view, because the actual view title may be hidden.
+  // Title label was added because iPads using iOS 18 or higher
+  // use the floating tab bar with a regular horizontal size class.
+  UILabel *titleViewlabel = [[UILabel alloc] initWithFrame:CGRectMake(0, 0, self.view.frame.size.width, 150)];
+  titleViewlabel.numberOfLines = 0;
+  titleViewlabel.lineBreakMode = NSLineBreakByWordWrapping;
+  titleViewlabel.textAlignment = NSTextAlignmentCenter;
+  titleViewlabel.font = [UIFont semiBoldPalaceFontOfSize: 16];
+  titleViewlabel.text = NSLocalizedString(@"Browse Books", nil);
+  titleViewlabel.accessibilityTraits = UIAccessibilityTraitHeader;
+  self.viewController.navigationItem.titleView = titleViewlabel;
 
 #ifdef SIMPLYE
   [self setNavigationLeftBarButtonForVC:self.viewController];

--- a/Palace/Catalog/Search/TPPCatalogSearchViewController.m
+++ b/Palace/Catalog/Search/TPPCatalogSearchViewController.m
@@ -26,6 +26,7 @@
 @property (nonatomic) TPPReloadView *reloadView;
 @property (nonatomic) UISearchBar *searchBar;
 @property (nonatomic) UILabel *noResultsLabel;
+@property (nonatomic) UILabel *startSearchLabel;
 @property (nonatomic) TPPFacetBarView *facetBarView;
 @property (nonatomic) NSTimer *debounceTimer;
 
@@ -92,6 +93,27 @@
   [self.noResultsLabel sizeToFit];
   self.noResultsLabel.hidden = YES;
   [self.view addSubview:self.noResultsLabel];
+  
+  // Show instructions for user how to search books or authors.
+  // This message is shown in the empty search view before first search,
+  // and is replaced with actual search results (or "no results found") after search
+  self.startSearchLabel = [[UILabel alloc] init];
+  self.startSearchLabel.text = NSLocalizedString(@"You can search for a book or an author using the search bar above.\n\nIf you want to search through all books, ensure you are on the Browse Books tab with 'All' selected.", nil);
+  self.startSearchLabel.font = [UIFont palaceFontOfSize:18];
+  self.startSearchLabel.textColor = [UIColor grayColor];
+  self.startSearchLabel.numberOfLines = 0;
+  self.startSearchLabel.textAlignment = NSTextAlignmentCenter;
+  self.startSearchLabel.hidden = NO;
+  
+  [self.view addSubview:self.startSearchLabel];
+  
+  self.startSearchLabel.translatesAutoresizingMaskIntoConstraints = NO;
+  [NSLayoutConstraint activateConstraints:@[
+    [self.startSearchLabel.centerXAnchor constraintEqualToAnchor:self.view.centerXAnchor],
+    [self.startSearchLabel.centerYAnchor constraintEqualToAnchor:self.view.centerYAnchor],
+    [self.startSearchLabel.leadingAnchor constraintGreaterThanOrEqualToAnchor:self.view.leadingAnchor constant:20],
+    [self.startSearchLabel.trailingAnchor constraintLessThanOrEqualToAnchor:self.view.trailingAnchor constant:-20]
+  ]];
   
   __weak TPPCatalogSearchViewController *weakSelf = self;
   self.reloadView = [[TPPReloadView alloc] init];
@@ -218,6 +240,7 @@ didSelectItemAtIndexPath:(NSIndexPath *const)indexPath
 {
   self.collectionView.hidden = YES;
   self.noResultsLabel.hidden = YES;
+  self.startSearchLabel.hidden = YES;
   self.reloadView.hidden = YES;
   self.searchActivityIndicatorView.hidden = NO;
   [self.searchActivityIndicatorView startAnimating];

--- a/Palace/Catalog/Search/TPPCatalogSearchViewController.m
+++ b/Palace/Catalog/Search/TPPCatalogSearchViewController.m
@@ -84,6 +84,8 @@
   [self.searchBar sizeToFit];
   [self.searchBar becomeFirstResponder];
   
+  [self addSearchBarAsTitleViewOrSubview];
+  
   self.noResultsLabel = [[UILabel alloc] init];
   self.noResultsLabel.text = NSLocalizedString(@"No Results Found", nil);
   self.noResultsLabel.font = [UIFont palaceFontOfSize:17];
@@ -101,8 +103,6 @@
   };
   self.reloadView.hidden = YES;
   [self.view addSubview:self.reloadView];
-  
-  self.navigationItem.titleView = self.searchBar;
 }
 
 - (void)viewWillLayoutSubviews
@@ -120,20 +120,14 @@
   [self.noResultsLabel integralizeFrame];
 
   [self.reloadView centerInSuperview];
+  
+
 }
 
 - (void)viewDidLayoutSubviews
 {
   [super viewDidLayoutSubviews];
-  UIEdgeInsets newInsets = UIEdgeInsetsMake(CGRectGetMaxY(self.facetBarView.frame),
-                                            0,
-                                            self.bottomLayoutGuide.length,
-                                            0);
-  if (!UIEdgeInsetsEqualToEdgeInsets(self.collectionView.contentInset, newInsets)) {
-    //self.collectionView.contentInset = newInsets; //disabled by Ellibs
-    self.collectionView.contentInset = UIEdgeInsetsMake(130, 0, self.bottomLayoutGuide.length, 0); //Added by Ellibs
-    //self.collectionView.scrollIndicatorInsets = newInsets; //disabled by Ellibs
-  }
+  [self updateSearchResultContentInsets];
 }
 
 - (CGFloat)collectionView:(UICollectionView *)collectionView layout:(UICollectionViewLayout *)collectionViewLayout minimumLineSpacingForSectionAtIndex:(NSInteger)section
@@ -327,6 +321,111 @@ didSelectItemAtIndexPath:(NSIndexPath *const)indexPath
   //[self.facetBarView autoPinEdgeToSuperviewEdge:ALEdgeLeading];
   //[self.facetBarView autoPinEdgeToSuperviewEdge:ALEdgeTrailing];
   //[self.facetBarView autoPinEdgeToSuperviewMargin:ALEdgeTop];
+}
+
+- (void)addSearchBarAsTitleViewOrSubview
+{
+  // Set some defaults and checks
+  // to help handle all different cases of
+  // how searchbars and searchsheets are shown in the app
+  BOOL isRunningiOS18OrLater = NO;
+  BOOL hasParentCatalogNavigationController = [[self parentViewController] isKindOfClass:[TPPCatalogNavigationController class]];
+  BOOL isUsingPadDevice = [[UIDevice currentDevice] userInterfaceIdiom] == UIUserInterfaceIdiomPad;
+  BOOL isUsingRegularSizeClass = [[TPPRootTabBarController sharedController] traitCollection].horizontalSizeClass == UIUserInterfaceSizeClassRegular;
+  
+  if (@available(iOS 18, *)) {
+    isRunningiOS18OrLater = YES;
+  }
+  
+  // Because of the floating tab bar we can not use the default approach
+  BOOL shouldAddSearchBarAsSubview = hasParentCatalogNavigationController && isUsingPadDevice && isUsingRegularSizeClass && isRunningiOS18OrLater;
+
+  // Determine the display style for the search bar:
+  // a) As a subview in the current view, keeping the top bar intact
+  // b) Integrated into the top bar, the default
+  // Note: In MyBooks views, the search sheet is already opened within the view,
+  // so option b) is used there also
+  if (shouldAddSearchBarAsSubview) {
+    [self.view addSubview:self.searchBar];
+    [self updateSearchBarFrame];
+  } else {
+    // use the default approach
+    self.navigationItem.titleView = self.searchBar;
+  }
+  
+}
+
+- (void)updateSearchBarFrame
+{
+  CGFloat searchBarOffsetX= 0.0;
+  CGFloat searchBarWidth = self.view.frame.size.width;
+  CGFloat searchBarHeight = self.searchBar.frame.size.height;
+  // This default is just an approximation
+  // to position the search bar in catalog Objective-C views
+  // similarly to the MyBooks SwiftUI views.
+  CGFloat searchBarOffsetY = 86.0;
+  
+  self.searchBar.frame = CGRectMake(searchBarOffsetX,
+                                    searchBarOffsetY,
+                                    searchBarWidth,
+                                    searchBarHeight);
+}
+
+- (void)updateSearchResultContentInsets
+{
+  // Set some defaults first
+  BOOL isRunningiOS18OrLater = NO;
+  CGFloat bottomContentInset = self.view.safeAreaInsets.bottom;
+  CGFloat leftContentInset = 0.0;
+  CGFloat rightContentInset = 0.0;
+  // Top inset value 75.0 is the default
+  // and used for search sheets opened from MyBooks (SwiftUI) views
+  CGFloat topContentInset = 75.0;
+
+  // Then some checks to help handle all different cases of
+  // how searchbars and searchsheets are shown in the app
+  BOOL hasParentCatalogNavigationController = [[self parentViewController] isKindOfClass:[TPPCatalogNavigationController class]];
+  BOOL isUsingPadDevice = [[UIDevice currentDevice] userInterfaceIdiom] == UIUserInterfaceIdiomPad;
+  BOOL isUsingRegularSizeClass = [[TPPRootTabBarController sharedController] traitCollection].horizontalSizeClass == UIUserInterfaceSizeClassRegular;
+  
+  if (@available(iOS 18, *)) {
+    isRunningiOS18OrLater = YES;
+  }
+  
+  BOOL isFloatingTabBarVisibleOnPad = isUsingRegularSizeClass && isRunningiOS18OrLater;
+  
+  // If user is in MyBooks views and opens search sheet from there,
+  // the parent controller is different, these are skipped.
+  // and the default topContentInsent is used instead.
+  if (hasParentCatalogNavigationController) {
+    // User has navigated to the Browse Books (Objective-C) view
+    // and opened the search sheet
+    
+    if (isUsingPadDevice) {
+      // Device is iPad
+      
+      if (isFloatingTabBarVisibleOnPad) {
+        [self updateSearchBarFrame];
+        topContentInset = 150.0;
+      } else {
+        // Device interface is compact (or unspecified) OR iOS is older than 18.
+        // Bottom tab bar is visible.
+        topContentInset = 100.0;
+      }
+      
+    } else {
+      // Device is iPhone
+      topContentInset = 120.0;
+    }
+    
+  }
+  
+  // Set insets around content in search sheet (around the search results).
+  // Top inset varies based on device and style of search bar.
+  self.collectionView.contentInset = UIEdgeInsetsMake(topContentInset,
+                                                      leftContentInset,
+                                                      bottomContentInset,
+                                                      rightContentInset);
 }
 
 #pragma mark NYPLEntryPointViewDelegate

--- a/Palace/MyBooks/Views/Favorites/FavoritesMainViewController.swift
+++ b/Palace/MyBooks/Views/Favorites/FavoritesMainViewController.swift
@@ -6,30 +6,61 @@ import Foundation
 import SwiftUI
 
 class FavoritesMainViewController: NSObject {
-  
+
+  // Creating and wrapping the Favorites tab view controller
   @MainActor @objc static func makeSwiftUIView(
     dismissHandler: @escaping (() -> Void)
   ) -> UIViewController {
-    
+
+    // We are creating a UIHostingController to integrate the
+    // FavoritesMainView (a SwiftUI view) into the app's UIKit view hierarchy.
+    // FavoritesViewModel contains the main logic for this view,
+    // and we pass it as parameter for the FavoritesMainView
     let hostingController = UIHostingController(
       rootView: FavoritesMainView(
         favoritesViewModel: FavoritesViewModel()
       )
     )
-    
+
+    // Icons and title for the tab, displayed in the bottom tab bar
+    // on iPhones with all iOS versions and on iPads with iOS 17 or lower.
+    // For iPads running iOS 18 or higher with a regular horizontal size class,
+    // only the title is displayed in the floating tab bar, and icons are not used.
     hostingController.title = Strings.MyBooksView.favoritesAndReadNavTitle
-    hostingController.tabBarItem.image = UIImage(named: "Favorites")
+    hostingController.tabBarItem.image =  UIImage(named: "Favorites")
     hostingController.tabBarItem.selectedImage = UIImage(named: "FavoritesSelected")
-    hostingController.tabBarItem.imageInsets = UIEdgeInsets(top: 4.0, left: 0.0, bottom: -4.0, right: 0.0)
-    hostingController.navigationItem.backButtonTitle = NSLocalizedString("Back", comment: "Back button")
-    hostingController.navigationItem.titleView?.tintColor = UIColor(named: "ColorEkirjastoBlack")
-    
+    hostingController.tabBarItem.imageInsets = UIEdgeInsets(
+      top: 4.0, left: 0.0, bottom: -4.0, right: 0.0
+    )
+
+    // Title view label is displayed at the top of the view,
+    // below the floating tab bar, for iPads running iOS 18 or higher
+    // with a regular horizontal size class.
+    //The style matches the lane titles of the catalog's ungrouped view.
+    let titleViewLabel = UILabel()
+    titleViewLabel.text = Strings.MyBooksView.favoritesAndReadNavTitle
+    titleViewLabel.font = UIFont.palaceFont(ofSize: 16)
+    titleViewLabel.textAlignment = .center
+    titleViewLabel.accessibilityTraits = .header
+    hostingController.navigationItem.titleView = titleViewLabel
+
+    // Button text for returning to this view.
+    // This button is displayed in book detail view and search view,
+    // when user can go back to Favorites view.
+    hostingController.navigationItem.backButtonTitle = Strings.MyBooksView.favoritesAndReadNavTitle
+
+    // Navigation controllers stack views and allow us to navigate
+    // from one view to another and back within the app.
+    // Favorites tab has it's own navigation controller,
+    // which means that this navigation controller handles
+    // navigation specifically for the Favorites section of the app.
     let navigationController = UINavigationController(
       rootViewController: hostingController
     )
-    
+
+    // UINavigationController is subclass of UIViewController.
     return navigationController
-    
+
   }
-  
+
 }

--- a/Palace/MyBooks/Views/LoansAndHolds/LoansAndHoldsViewController.swift
+++ b/Palace/MyBooks/Views/LoansAndHolds/LoansAndHoldsViewController.swift
@@ -7,30 +7,60 @@ import SwiftUI
 
 class LoansAndHoldsViewController: NSObject {
 
+  // Creating and wrapping the Loans+Holds tab view controller
   @MainActor @objc static func makeSwiftUIView(
     dismissHandler: @escaping (() -> Void)
   ) -> UIViewController {
-    
+
+    // We are creating a UIHostingController to integrate the
+    // LoansAndHoldsMainView (a SwiftUI view) into the app's UIKit view hierarchy.
+    // LoansViewModel and HoldsViewModel contain the main logic for these subviews,
+    // and we pass them as parameters for the LoansAndHoldsMainView
     let hostingController = UIHostingController(
       rootView: LoansAndHoldsView(
         loansViewModel: LoansViewModel(),
         holdsViewModel: HoldsViewModel()
       )
     )
-    
+
+    // Icons and title for the tab, displayed in the bottom tab bar
+    // on iPhones with all iOS versions and on iPads with iOS 17 or lower.
+    // For iPads running iOS 18 or higher with a regular horizontal size class,
+    // only the title is displayed in the floating tab bar, and icons are not used.
     hostingController.title = Strings.MyBooksView.loansAndHoldsNavTitle
     hostingController.tabBarItem.image = UIImage(named: "LoansAndHolds")
     hostingController.tabBarItem.selectedImage = UIImage(named: "LoansAndHoldsSelected")
-    hostingController.tabBarItem.imageInsets = UIEdgeInsets(top: 4.0, left: 0.0, bottom: -4.0, right: 0.0)
-    hostingController.navigationItem.backButtonTitle = NSLocalizedString("Back", comment: "Back button")
-    hostingController.navigationItem.titleView?.tintColor = UIColor(named: "ColorEkirjastoBlack")
-    
+    hostingController.tabBarItem.imageInsets = UIEdgeInsets(
+      top: 4.0, left: 0.0, bottom: -4.0, right: 0.0)
+
+    // Title view label is displayed at the top of the view,
+    // below the floating tab bar, for iPads running iOS 18 or higher
+    // with a regular horizontal size class.
+    //The style matches the lane titles of the catalog's ungrouped view.
+    let titleViewLabel = UILabel()
+    titleViewLabel.text = Strings.MyBooksView.loansAndHoldsNavTitle
+    titleViewLabel.font = UIFont.palaceFont(ofSize: 16)
+    titleViewLabel.textAlignment = .center
+    titleViewLabel.accessibilityTraits = .header
+    hostingController.navigationItem.titleView = titleViewLabel
+
+    // Button text for returning to this view.
+    // This button is displayed in book detail view and search view,
+    // when user can go back to Loans and Holds view.
+    hostingController.navigationItem.backButtonTitle = Strings.MyBooksView.loansAndHoldsNavTitle
+
+    // Navigation controllers stack views and allow us to navigate
+    // from one view to another and back within the app.
+    // Loans+Holds tab has it's own navigation controller,
+    // which means that this navigation controller handles
+    // navigation specifically for the Loans+Holds section of the app.
     let navigationController = UINavigationController(
       rootViewController: hostingController
     )
-    
+
+    // UINavigationController is subclass of UIViewController.
     return navigationController
-    
+
   }
-    
+
 }

--- a/Palace/Settings/NewSettings/TPPSettingsView.swift
+++ b/Palace/Settings/NewSettings/TPPSettingsView.swift
@@ -20,7 +20,7 @@ struct TPPSettingsView: View {
   var body: some View {
     settingsListView
       .navigationBarItems(leading: leadingBarButton)
-      .navigationBarTitle(Strings.Settings.settings)
+      .navigationBarTitle(Strings.Settings.settingsNavTitle)
       .onReceive(NotificationCenter.default.publisher(for: UIDevice.orientationDidChangeNotification)) { _ in
         self.orientation = UIDevice.current.orientation
       }

--- a/Palace/Settings/NewSettings/TPPSettingsViewController.swift
+++ b/Palace/Settings/NewSettings/TPPSettingsViewController.swift
@@ -10,14 +10,23 @@ import Foundation
 import SwiftUI
 
 class TPPSettingsViewController: NSObject {
+  
   @objc static func makeSwiftUIView(dismissHandler: @escaping (() -> Void)) -> UIViewController {
     let controller = UIHostingController(rootView: TPPSettingsView())
-    controller.title = Strings.Settings.settings
+    controller.title = Strings.Settings.settingsNavTitle
     controller.tabBarItem.image = UIImage(named: "Settings")
     controller.tabBarItem.selectedImage = UIImage(named: "SettingsSelected")
-    controller.tabBarItem.imageInsets = UIEdgeInsets(top: 4.0, left: 0.0, bottom: -4.0, right: 0.0);
+    controller.tabBarItem.imageInsets = UIEdgeInsets(top: 4.0, left: 0.0, bottom: -4.0, right: 0.0)
+    controller.navigationItem.backButtonTitle = Strings.Settings.settingsNavTitle
+    
+    let titleViewLabel = UILabel()
+    titleViewLabel.text = Strings.Settings.settingsNavTitle
+    titleViewLabel.font = UIFont.palaceFont(ofSize: 16)
+    titleViewLabel.accessibilityTraits = .header
+    controller.navigationItem.titleView = titleViewLabel
+   
     let navigationController = UINavigationController(rootViewController: controller)
-
     return navigationController
   }
+  
 }

--- a/Palace/Utilities/Localization/Strings.swift
+++ b/Palace/Utilities/Localization/Strings.swift
@@ -94,6 +94,10 @@ struct Strings {
     static let returnActionTitle = NSLocalizedString("Return", comment: "Button title for keeping an audiobook")
   }
   
+  struct Search {
+    static let startSearchInstructionMessage = NSLocalizedString("You can search for a book or an author using the search bar above.\n\nIf you want to search through all books, ensure you are on the Browse Books tab with 'All' selected.", comment: "Instructions for users on how to perform a search. Visible in the view before the first search. Keep the newlines to preserve paragraph formatting in the UI.")
+  }
+  
   struct Settings {
     static let settings = NSLocalizedString("Settings", comment: "")
     static let settingsNavTitle = NSLocalizedString("Settings", comment: "Tab title for settings view")

--- a/Palace/Utilities/Localization/Strings.swift
+++ b/Palace/Utilities/Localization/Strings.swift
@@ -96,6 +96,7 @@ struct Strings {
   
   struct Settings {
     static let settings = NSLocalizedString("Settings", comment: "")
+    static let settingsNavTitle = NSLocalizedString("Settings", comment: "Tab title for settings view")
     static let libraries = NSLocalizedString("Libraries", comment: "A title for a list of libraries the user may select or add to.")
     static let addLibrary = NSLocalizedString("Add Library", comment: "Title of button to add a new library")
     static let aboutApp = NSLocalizedString("About App", comment: "")

--- a/Palace/Utilities/Localization/Transifex/txstrings.json
+++ b/Palace/Utilities/Localization/Transifex/txstrings.json
@@ -1194,6 +1194,9 @@
       "You are at position %ld in the queue for this book." : {
          "string" : "You are at position %ld in the queue for this book."
       },
+      "You can search for a book or an author using the search bar above.\n\nIf you want to search through all books, ensure you are on the Browse Books tab with 'All' selected." : {
+         "string" : "You can search for a book or an author using the search bar above.\n\nIf you want to search through all books, ensure you are on the Browse Books tab with 'All' selected."
+      },
       "You have already checked out this loan. You may need to refresh your My Books list to download the title." : {
          "string" : "You have already checked out this loan. You may need to refresh your My Books list to download the title."
       },
@@ -2495,6 +2498,9 @@
       "You are at position %ld in the queue for this book." : {
          "string" : "Olet tämän kirjan varausjonossa sijalla %ld"
       },
+      "You can search for a book or an author using the search bar above.\n\nIf you want to search through all books, ensure you are on the Browse Books tab with 'All' selected." : {
+         "string" : "Voit etsiä kirjaa tai kirjailijaa yllä olevan haun avulla.\n\nJos haluat kohdistaa haun kaikkiin kirjoihin, varmista, että olet Selaa-välilehdellä ja että 'Kaikki' on valittuna."
+      },
       "You have already checked out this loan. You may need to refresh your My Books list to download the title." : {
          "string" : "Olet jo lainannut tämän teoksen. Sinun on ehkä päivitettävä Omat lainat -listasi, jotta voit ladata teoksen."
       },
@@ -3795,6 +3801,9 @@
       },
       "You are at position %ld in the queue for this book." : {
          "string" : "Du är på plats %ld i kön till den här boken."
+      },
+      "You can search for a book or an author using the search bar above.\n\nIf you want to search through all books, ensure you are on the Browse Books tab with 'All' selected." : {
+         "string" : "Du kan söka efter en bok eller en författare med hjälp av sökfältet ovan.\n\nOm du vill rikta sökningen till alla böcker, se till att du är på fliken Bläddra böcker och att 'Alla' är valt."
       },
       "You have already checked out this loan. You may need to refresh your My Books list to download the title." : {
          "string" : "Du har redan lånat denna bok. Det kan hända att du måste uppdatera listan i Mina lån för att ladda ner titeln."


### PR DESCRIPTION
### What's this do?
- Search UI was improved
  - when the search is initially opened, a search help text is displayed in the view
  - the user can view the search field and search results without them being sometimes obscured by other elements
  - titles were added to tab views for clarification

### Why are we doing this?
- we are addressing the changes brought by iOS 18 to iPads
- we are fixing some bugs in the UI
- https://jira.it.helsinki.fi/browse/EKIRJASTO-444 

### How should this be tested?
- Test with device
  - especially iPads with iOS higher than 18, compact and regular horizontal size  

### Did someone actually run this code to verify it works?
- Tested with simulator
- Tested with device (iPad with iOS < 18, iPhone 18.6) 

### Have the Transifex translators been notified?
- Review was requested for new localisations
