### PR TITLE
EKIRJASTO-86 Accessibility changes

### DIFF
--- a/Palace/AppInfrastructure/TPPConfiguration+Ekirjasto.swift
+++ b/Palace/AppInfrastructure/TPPConfiguration+Ekirjasto.swift
@@ -113,7 +113,7 @@ extension TPPConfiguration {
   
   @objc static func iconColor() -> UIColor {
     if #available(iOS 13, *) {
-      return UIColor(named: "ColorEkirjastoIcon")!
+      return UIColor(named: "ColorEkirjastoBlack")!
     } else {
       return .black
     }

--- a/Palace/Book/UI/BookDetailView/TPPBookDetailTableView.swift
+++ b/Palace/Book/UI/BookDetailView/TPPBookDetailTableView.swift
@@ -312,7 +312,6 @@ private let standardCellHeight: CGFloat = 44.0
       moreButton.setTitleColor(.black, for: .normal)
     }
     moreButton.titleLabel?.font = UIFont.palaceFont(ofSize: 14) //Edited by Ellibs
-    moreButton.tintColor = UIColor(named: "ColorEkirjastoGreen") //Added by Ellibs
     moreButton.contentHorizontalAlignment = .trailing //Added by Ellibs
     moreButton.semanticContentAttribute = .forceRightToLeft //Added by Ellibs
     moreButton.setImage(UIImage(named: "ArrowRight"), for: .normal) //Added by Ellibs

--- a/Palace/Catalog/Feed/Grouped/TPPCatalogGroupedFeedViewController.m
+++ b/Palace/Catalog/Feed/Grouped/TPPCatalogGroupedFeedViewController.m
@@ -314,7 +314,7 @@ viewForHeaderInSection:(NSInteger const)section
     button.titleLabel.lineBreakMode = NSLineBreakByTruncatingTail;
     button.tag = section;
     TPPCatalogLane *const lane = self.feed.lanes[button.tag];
-    button.accessibilityLabel = [[NSString alloc] initWithFormat:NSLocalizedString(@"More %@ books", nil), lane.title];
+    button.accessibilityLabel = [[NSString alloc] initWithFormat:NSLocalizedString(@"%@ -lane", nil), lane.title];
     button.accessibilityTraits = UIAccessibilityTraitHeader;
     button.accessibilityHint = NSLocalizedString(@"Tap to view more books in this category", "Descriptive label for screen readers");
     [button addTarget:self
@@ -324,7 +324,7 @@ viewForHeaderInSection:(NSInteger const)section
     [view addSubview:button];
   }
   
-  // Creates a button with text and arrrow and allows the user to tap on it to view more books in the category.
+  // Creates a button with text and arrow and allows the user to tap on it to view more books in the category.
   {
     UIButton *const button = [UIButton buttonWithType:UIButtonTypeSystem];
     button.titleLabel.font = [UIFont palaceFontOfSize:14]; //Edited by Ellibs
@@ -341,7 +341,7 @@ viewForHeaderInSection:(NSInteger const)section
     button.frame = CGRectMake(CGRectGetWidth(view.frame) - CGRectGetWidth(button.frame) - 30, //Edited by Ellibs
                               13,
                               CGRectGetWidth(button.frame)+30, //Edited by Ellibs
-                              CGRectGetHeight(button.frame));
+                              CGRectGetHeight(button.frame)+15);
     button.tag = section;
     TPPCatalogLane *const lane = self.feed.lanes[button.tag];
     button.accessibilityLabel = [[NSString alloc] initWithFormat:NSLocalizedString(@"More %@ books", nil), lane.title];

--- a/Palace/Catalog/Lane/TPPCatalogLaneCell.m
+++ b/Palace/Catalog/Lane/TPPCatalogLaneCell.m
@@ -73,7 +73,7 @@
       button.imageEdgeInsets = UIEdgeInsetsMake(0, 0, 6, 0);
     } else if ([book defaultBookContentType] == TPPBookContentTypePdf) {
       //Add accessibility label for Pdf
-      button.accessibilityLabel = [NSString stringWithFormat:NSLocalizedString(@"%@ by %@, Pdf", nil), book.title, book.authors];
+      button.accessibilityLabel = [NSString stringWithFormat:NSLocalizedString(@"%@ by %@, pdf", nil), book.title, book.authors];
     } else if ([book defaultBookContentType] == TPPBookContentTypeEpub) {
       //Add accessibility label for Epub
       button.accessibilityLabel = [NSString stringWithFormat:NSLocalizedString(@"%@ by %@, ebook", nil), book.title, book.authors];

--- a/Palace/Catalog/Lane/TPPCatalogLaneCell.m
+++ b/Palace/Catalog/Lane/TPPCatalogLaneCell.m
@@ -59,14 +59,24 @@
      forControlEvents:UIControlEventTouchUpInside];
     button.exclusiveTouch = YES;
     [buttons addObject:button];
-    button.accessibilityLabel = book.title;
+    //Add accessibilitylable for a book of unknown type
+    button.accessibilityLabel = [NSString stringWithFormat:NSLocalizedString(@"%@ by %@", nil), book.title, book.authors];
+    //Add hint telling what happens when title is tapped
+    button.accessibilityHint = [NSString stringWithFormat:NSLocalizedString(@"Show book's page", nil)];
     [self.scrollView addSubview:button];
     
     if ([book defaultBookContentType] == TPPBookContentTypeAudiobook) {
+      //Add accessibility label for audiobook
+      button.accessibilityLabel = button.accessibilityLabel = [NSString stringWithFormat:NSLocalizedString(@"%@ by %@, audiobook", nil), book.title, book.authors];;
       TPPContentBadgeImageView *badge = [[TPPContentBadgeImageView alloc] initWithBadgeImage:TPPBadgeImageAudiobook];
       [TPPContentBadgeImageView pinWithBadge:badge toView:button isLane:YES];
-      button.accessibilityLabel = [@"Audiobook: " stringByAppendingString:book.title];
       button.imageEdgeInsets = UIEdgeInsetsMake(0, 0, 6, 0);
+    } else if ([book defaultBookContentType] == TPPBookContentTypePdf) {
+      //Add accessibility label for Pdf
+      button.accessibilityLabel = [NSString stringWithFormat:NSLocalizedString(@"%@ by %@, Pdf", nil), book.title, book.authors];
+    } else if ([book defaultBookContentType] == TPPBookContentTypeEpub) {
+      //Add accessibility label for Epub
+      button.accessibilityLabel = [NSString stringWithFormat:NSLocalizedString(@"%@ by %@, ebook", nil), book.title, book.authors];
     }
   }];
   

--- a/Palace/Catalog/Search/TPPCatalogSearchViewController.m
+++ b/Palace/Catalog/Search/TPPCatalogSearchViewController.m
@@ -77,10 +77,22 @@
   
   self.searchBar = [[UISearchBar alloc] init];
   self.searchBar.delegate = self;
-  self.searchBar.placeholder = NSLocalizedString(@"Search", nil);
-  self.searchBar.searchTextField.leftView.tintColor = [UIColor colorNamed:@"ColorEkirjastoSearchBarText"];
+  
+  // Create an attribute with desired color for the placeholder text
+  NSDictionary *attributes = @{
+    NSForegroundColorAttributeName: [UIColor colorNamed:@"ColorEkirjastoAlwaysBlack"]
+  };
+  // Create placeholder with attributes
+  NSAttributedString *attributedPlaceholder = [[NSAttributedString alloc] initWithString:NSLocalizedString(@"Search", nil) attributes:attributes];
+  // Set the attributed placeholder
+  self.searchBar.searchTextField.attributedPlaceholder = attributedPlaceholder;
+  // The magnifying glass color
+  self.searchBar.searchTextField.leftView.tintColor = [UIColor colorNamed:@"ColorEkirjastoAlwaysBlack"];
+  // The user-written text color
   self.searchBar.searchTextField.textColor = [UIColor colorNamed:@"ColorEkirjastoAlwaysBlack"];
+  // The blinking line color
   self.searchBar.searchTextField.tintColor = [UIColor colorNamed:@"ColorEkirjastoSearchBarText"];
+  // Color of search background
   self.searchBar.searchTextField.backgroundColor = [UIColor colorNamed:@"ColorEkirjastoSearchBar"];
   [self.searchBar sizeToFit];
   [self.searchBar becomeFirstResponder];
@@ -100,7 +112,7 @@
   self.startSearchLabel = [[UILabel alloc] init];
   self.startSearchLabel.text = NSLocalizedString(@"You can search for a book or an author using the search bar above.\n\nIf you want to search through all books, ensure you are on the Browse Books tab with 'All' selected.", nil);
   self.startSearchLabel.font = [UIFont palaceFontOfSize:18];
-  self.startSearchLabel.textColor = [UIColor grayColor];
+  self.startSearchLabel.textColor = [UIColor colorNamed:@"ColorEkirjastoBlack"];
   self.startSearchLabel.numberOfLines = 0;
   self.startSearchLabel.textAlignment = NSTextAlignmentCenter;
   self.startSearchLabel.hidden = NO;

--- a/Palace/MyBooks/Views/Favorites/Favorites/FavoritesView.swift
+++ b/Palace/MyBooks/Views/Favorites/Favorites/FavoritesView.swift
@@ -79,7 +79,7 @@ struct FavoritesView: View {
           VStack {
             // user is logged in and has no favorite books
             // show instructions how to add a book to favorites
-            emptyHoldsView
+            emptyFavoritesView
           }
           .frame(minHeight: geometry.size.height)
           .refreshable {
@@ -119,10 +119,10 @@ struct FavoritesView: View {
 
   }
 
-  @ViewBuilder private var emptyHoldsView: some View {
+  @ViewBuilder private var emptyFavoritesView: some View {
     Text(Strings.MyBooksView.favoritesEmptyViewMessage)
       .multilineTextAlignment(.center)
-      .foregroundColor(.gray)
+      .foregroundColor(Color("ColorEkirjastoBlack"))
       .horizontallyCentered()
       .verticallyCentered()
   }
@@ -130,7 +130,7 @@ struct FavoritesView: View {
   @ViewBuilder private var logInInstructionsView: some View {
     Text(Strings.MyBooksView.favoritesNotLoggedInViewMessage)
       .multilineTextAlignment(.center)
-      .foregroundColor(.gray)
+      .foregroundColor(Color("ColorEkirjastoBlack"))
       .horizontallyCentered()
       .verticallyCentered()
   }

--- a/Palace/MyBooks/Views/LoansAndHolds/Holds/HoldsView.swift
+++ b/Palace/MyBooks/Views/LoansAndHolds/Holds/HoldsView.swift
@@ -121,7 +121,7 @@ struct HoldsView: View {
   @ViewBuilder private var emptyHoldsView: some View {
     Text(Strings.MyBooksView.holdsEmptyViewMessage)
       .multilineTextAlignment(.center)
-      .foregroundColor(.gray)
+      .foregroundColor(Color("ColorEkirjastoBlack"))
       .horizontallyCentered()
       .verticallyCentered()
   }
@@ -129,7 +129,7 @@ struct HoldsView: View {
   @ViewBuilder private var logInInstructionsView: some View {
     Text(Strings.MyBooksView.holdsNotLoggedInViewMessage)
       .multilineTextAlignment(.center)
-      .foregroundColor(.gray)
+      .foregroundColor(Color("ColorEkirjastoBlack"))
       .horizontallyCentered()
       .verticallyCentered()
   }

--- a/Palace/MyBooks/Views/LoansAndHolds/Loans/LoansView.swift
+++ b/Palace/MyBooks/Views/LoansAndHolds/Loans/LoansView.swift
@@ -117,7 +117,7 @@ struct LoansView: View {
   @ViewBuilder private var emptyLoansView: some View {
     Text(Strings.MyBooksView.loansEmptyViewMessage)
       .multilineTextAlignment(.center)
-      .foregroundColor(.gray)
+      .foregroundColor(Color("ColorEkirjastoBlack"))
       .horizontallyCentered()
       .verticallyCentered()
   }
@@ -125,7 +125,7 @@ struct LoansView: View {
   @ViewBuilder private var logInInstructionsView: some View {
     Text(Strings.MyBooksView.loansNotLoggedInViewMessage)
       .multilineTextAlignment(.center)
-      .foregroundColor(.gray)
+      .foregroundColor(Color("ColorEkirjastoBlack"))
       .horizontallyCentered()
       .verticallyCentered()
   }

--- a/Palace/MyBooks/Views/SharedUIComponents/Facet/FacetView.swift
+++ b/Palace/MyBooks/Views/SharedUIComponents/Facet/FacetView.swift
@@ -33,16 +33,18 @@ struct FacetView: View {
 
   private var sortView: some View {
 
+    //Create the button with the active sort option shown
     Button(action: {
       showAlert = true
     }) {
       Text(facetViewModel.activeSort.localizedString)
         .font(Font(uiFont: UIFont.boldPalaceFont(ofSize: 13)))
+        .accessibilityHint(String.localizedStringWithFormat(Strings.FacetView.facetHint, facetViewModel.groupName))
       Image("ArrowDown")
         .resizable()
         .scaledToFill()
         .frame(width: 19, height: 19)
-        .foregroundColor(Color("ColorEkirjastoGreen"))
+        .foregroundColor(Color("ColorEkirjastoBlack"))
         .padding(EdgeInsets(top: 1, leading: -8, bottom: -1, trailing: 8))
     }
 
@@ -60,7 +62,7 @@ struct FacetView: View {
         })
 
       buttons.append(
-        Alert.Button.default(Text(facetViewModel.activeSort.localizedString)) {
+        ActionSheet.Button.default(Text(facetViewModel.activeSort.localizedString)) {
           self.facetViewModel.activeSort = facetViewModel.activeSort
         })
     }

--- a/Palace/OnboardingScreens/TPPOnboardingView.swift
+++ b/Palace/OnboardingScreens/TPPOnboardingView.swift
@@ -117,7 +117,7 @@ struct TPPOnboardingView: View {
       } label: {
         Image(systemName: "xmark.circle.fill")
           .font(.title)
-          .foregroundColor(.gray)
+          .foregroundColor(.black)
           .padding(.top, 50)
       }
       .accessibility(label: Text(Strings.Generic.close))

--- a/Palace/OnboardingScreens/TPPOnboardingView.swift
+++ b/Palace/OnboardingScreens/TPPOnboardingView.swift
@@ -15,6 +15,14 @@ struct TPPOnboardingView: View {
   private var activationDistance: CGFloat = 0.8
   
   private var onboardingImageNames : [String]
+  
+  private var onboardingImageDescriptions : [String] = [
+    Strings.TPPOnboardingView.contentDescription1,
+    Strings.TPPOnboardingView.contentDescription2,
+    Strings.TPPOnboardingView.contentDescription3,
+    Strings.TPPOnboardingView.contentDescription4
+  ]
+  
   @GestureState private var translation: CGFloat = 0
   
   @State private var showLoginView = false
@@ -68,12 +76,14 @@ struct TPPOnboardingView: View {
   private func onboardingSlides() -> some View {
     GeometryReader { geometry in
       HStack(spacing: 0) {
-        ForEach(onboardingImageNames, id: \.self) { imageName in
-          Image(imageName)
+        ForEach(0..<onboardingImageNames.count, id: \.self) { index in
+          Image(onboardingImageNames[index])
             .resizable()
             .aspectRatio(contentMode: .fit)
             .frame(width: geometry.size.width)
-            .accessibility(label: Text(NSLocalizedString(imageName, comment: "Onboarding slide localised description")))
+            .accessibility(label: Text(onboardingImageDescriptions[index]))
+            .accessibilityHint(Text(Strings.TPPOnboardingView.swipeNextHint))
+            .accessibility(hint: Text(index == onboardingImageNames.count - 1 ? Strings.TPPOnboardingView.swipeCloseHint : Strings.TPPOnboardingView.swipeNextHint))
         }
       }
       .contentShape(Rectangle())
@@ -117,7 +127,7 @@ struct TPPOnboardingView: View {
       } label: {
         Image(systemName: "xmark.circle.fill")
           .font(.title)
-          .foregroundColor(.black)
+          .foregroundColor(Color("ColorEkirjastoBlack"))
           .padding(.top, 50)
       }
       .accessibility(label: Text(Strings.Generic.close))

--- a/Palace/OnboardingScreens/TPPOnboardingView.swift
+++ b/Palace/OnboardingScreens/TPPOnboardingView.swift
@@ -81,9 +81,8 @@ struct TPPOnboardingView: View {
             .resizable()
             .aspectRatio(contentMode: .fit)
             .frame(width: geometry.size.width)
-            .accessibility(label: Text(onboardingImageDescriptions[index]))
-            .accessibilityHint(Text(Strings.TPPOnboardingView.swipeNextHint))
-            .accessibility(hint: Text(index == onboardingImageNames.count - 1 ? Strings.TPPOnboardingView.swipeCloseHint : Strings.TPPOnboardingView.swipeNextHint))
+            .accessibilityLabel(Text(onboardingImageDescriptions[index]))
+            .accessibilityHint(Text(index == onboardingImageNames.count - 1 ? Strings.TPPOnboardingView.swipeCloseHint : Strings.TPPOnboardingView.swipeNextHint))
         }
       }
       .contentShape(Rectangle())

--- a/Palace/Utilities/Localization/Strings.swift
+++ b/Palace/Utilities/Localization/Strings.swift
@@ -286,6 +286,18 @@ struct Strings {
     static let bookRemovedFromFavoritesNotificationBannerMessage = NSLocalizedString("\"%@\" has been removed from your Favorites.", comment: "The message in a notification banner informing the user that the book is removed from user's favorite books")
   }
   
+  struct TPPCatalogLaneCell {
+    static let audioDescriptionEbook = NSLocalizedString("%@ by %@, ebook", comment: "BookCover cell accessibility label for ebook")
+    static let audioDescriptionPdf = NSLocalizedString("%@ by %@, pdf", comment: "BookCover cell accessibility label for pdf")
+    static let audioDescriptionAudiobook = NSLocalizedString("%@ by %@, audiobook", comment: "BookCover cell accessibility label for audiobook")
+    static let audioDescriptionUnknownFormat = NSLocalizedString("%@ by %@", comment: "BookCover cell accessibility label for unknown format")
+    static let audioDescriptionAction = NSLocalizedString("Show book's page", comment: "Describes what happens when the user taps the book cover")
+  }
+  
+  struct TPPCatalogGroupedViewController {
+    static let laneDescription = NSLocalizedString("%@ -lane", comment: "Audio description for lane title")
+  }
+  
   struct MyBooksView {
     static let loansAndHoldsNavTitle = NSLocalizedString("My Books", comment: "Tab title for loans and holds view")
     static let favoritesAndReadNavTitle = NSLocalizedString("Favorites", comment: "Tab title for favorites and read books view")
@@ -310,6 +322,7 @@ struct Strings {
   struct FacetView {
     static let author = NSLocalizedString("Author", comment: "")
     static let title = NSLocalizedString("Title", comment: "")
+    static let facetHint = NSLocalizedString("Change %@ choice", comment: "Read out hint when a facet is possibly selected")
   }
   
   struct BookCell {

--- a/Palace/Utilities/Localization/Strings.swift
+++ b/Palace/Utilities/Localization/Strings.swift
@@ -192,6 +192,15 @@ struct Strings {
     static let bookFormatForEBooks = NSLocalizedString("eBook", comment: "Common book format name for all eBooks.")
   }
   
+  struct TPPOnboardingView {
+    static let contentDescription1 = NSLocalizedString("Welcome to E-library! This service is provided by your local library.", comment: "Text of the first page of the onboarding tutorial")
+    static let contentDescription2 = NSLocalizedString("You can browse e-books and audiobooks by genre, book or author, or browse recommendation lists made by librarians.", comment: "Text of the second page of the onboarding tutorial")
+    static let contentDescription3 = NSLocalizedString("Browse the selection, borrow and read or listen! If a book is on loan, press \"reserve\" to get it when it becomes available.", comment: "Text of the third page of the onboarding tutorial")
+    static let contentDescription4 = NSLocalizedString("Or do you want something to listen to? The collection also includes an untold number of audiobooks! Click \"borrow\" to listen to the audiobook.", comment: "Text of the fourth page of the onboarding tutorial")
+    static let swipeNextHint = NSLocalizedString("Swipe left for next page.", comment: "Hint to show next image in the onboarding tutorial")
+    static let swipeCloseHint = NSLocalizedString("Swipe left to close tutorial.", comment: "Hint to close the onboarding tutorial")
+  }
+  
   struct TPPPDFNavigation {
     static let resume = NSLocalizedString("Resume", comment: "A button to continue reading title.")
   }

--- a/Palace/Utilities/Localization/Transifex/txstrings.json
+++ b/Palace/Utilities/Localization/Transifex/txstrings.json
@@ -36,6 +36,24 @@
       "%@ (file %@ of %d)" : {
          "string" : "%1$@ (file %2$@ of %3$d)"
       },
+      "%@ -lane" : {
+         "string" : "%@ -lane"
+      },
+      "%@ by %@" : {
+         "string" : "%1$@ by %2$@"
+      },
+      "%@ by %@, Pdf" : {
+         "string" : "%1$@ by %2$@, Pdf"
+      },
+      "%@ by %@, audiobook" : {
+         "string" : "%1$@ by %2$@, audiobook"
+      },
+      "%@ by %@, ebook" : {
+         "string" : "%1$@ by %2$@, ebook"
+      },
+      "%@ by %@, pdf" : {
+         "string" : "%1$@ by %2$@, pdf"
+      },
       "%@ played. %@ remaining." : {
          "string" : "%1$@ played. %2$@ remaining."
       },
@@ -329,6 +347,9 @@
       },
       "Category" : {
          "string" : "Category"
+      },
+      "Change %@ choice" : {
+         "string" : "Change %@ choice"
       },
       "Chapters" : {
          "string" : "Chapters"
@@ -918,6 +939,9 @@
       "Show Barcode" : {
          "string" : "Show Barcode"
       },
+      "Show book's page" : {
+         "string" : "Show book's page"
+      },
       "Sign In Error" : {
          "string" : "Sign In Error"
       },
@@ -1340,6 +1364,24 @@
       "%@ (file %@ of %d)" : {
          "string" : "%1$@ (tiedosto %2$@/%3$d)"
       },
+      "%@ -lane" : {
+         "string" : "%@ kategoria"
+      },
+      "%@ by %@" : {
+         "string" : "%1$@, tekijä %2$@"
+      },
+      "%@ by %@, Pdf" : {
+         "string" : "%1$@, tekijä %2$@, pdf"
+      },
+      "%@ by %@, audiobook" : {
+         "string" : "%1$@, tekijä %2$@, äänikirja"
+      },
+      "%@ by %@, ebook" : {
+         "string" : "%1$@, tekijä %2$@, e-kirja"
+      },
+      "%@ by %@, pdf" : {
+         "string" : "%1$@, tekijä %2$@, pdf"
+      },
       "%@ played. %@ remaining." : {
          "string" : "%1$@ toistettu. %2$@ jäljellä."
       },
@@ -1633,6 +1675,9 @@
       },
       "Category" : {
          "string" : "Luokka"
+      },
+      "Change %@ choice" : {
+         "string" : "Vaihda %@ valintaa"
       },
       "Chapters" : {
          "string" : "Luvut"
@@ -2222,6 +2267,9 @@
       "Show Barcode" : {
          "string" : "Näytä viivakoodi"
       },
+      "Show book's page" : {
+         "string" : "Näytä kirjan sivu"
+      },
       "Sign In Error" : {
          "string" : "Kirjautumisvirhe"
       },
@@ -2644,6 +2692,24 @@
       "%@ (file %@ of %d)" : {
          "string" : "%1$@ (fil %2$@ av %3$d)"
       },
+      "%@ -lane" : {
+         "string" : "%@ kategori"
+      },
+      "%@ by %@" : {
+         "string" : "%1$@ av %2$@"
+      },
+      "%@ by %@, Pdf" : {
+         "string" : "%1$@ av %2$@, pdf"
+      },
+      "%@ by %@, audiobook" : {
+         "string" : "%1$@ av %2$@, ljudbok"
+      },
+      "%@ by %@, ebook" : {
+         "string" : "%1$@ av %2$@, e-bok"
+      },
+      "%@ by %@, pdf" : {
+         "string" : "%1$@ av %2$@, pdf"
+      },
       "%@ played. %@ remaining." : {
          "string" : "%1$@ uppspelat. %2$@ återstår."
       },
@@ -2937,6 +3003,9 @@
       },
       "Category" : {
          "string" : "Kategori"
+      },
+      "Change %@ choice" : {
+         "string" : "Ändra %@ valet"
       },
       "Chapters" : {
          "string" : "Kapitel"
@@ -3525,6 +3594,9 @@
       },
       "Show Barcode" : {
          "string" : "Visa streckkod"
+      },
+      "Show book's page" : {
+         "string" : "Visa bokens sida"
       },
       "Sign In Error" : {
          "string" : "Inloggningsfel"

--- a/Palace/Utilities/Localization/Transifex/txstrings.json
+++ b/Palace/Utilities/Localization/Transifex/txstrings.json
@@ -321,6 +321,9 @@
       "Browse Books" : {
          "string" : "Browse Books"
       },
+      "Browse the selection, borrow and read or listen! If a book is on loan, press \"reserve\" to get it when it becomes available." : {
+         "string" : "Browse the selection, borrow and read or listen! If a book is on loan, press \"reserve\" to get it when it becomes available."
+      },
       "By signing in, you agree the End User License Agreement" : {
          "string" : "By signing in, you agree the End User License Agreement"
       },
@@ -717,6 +720,9 @@
       "Opens audiobook %@ for listening" : {
          "string" : "Opens audiobook %@ for listening"
       },
+      "Or do you want something to listen to? The collection also includes an untold number of audiobooks! Click \"borrow\" to listen to the audiobook." : {
+         "string" : "Or do you want something to listen to? The collection also includes an untold number of audiobooks! Click \"borrow\" to listen to the audiobook."
+      },
       "PDF" : {
          "string" : "PDF"
       },
@@ -996,6 +1002,12 @@
       "Swedish" : {
          "string" : "Swedish"
       },
+      "Swipe left for next page." : {
+         "string" : "Swipe left for next page."
+      },
+      "Swipe left to close tutorial." : {
+         "string" : "Swipe left to close tutorial."
+      },
       "Sync Bookmarks" : {
          "string" : "Sync Bookmarks"
       },
@@ -1191,6 +1203,9 @@
       "We're sorry. Our sign up system is currently down. Please try again later." : {
          "string" : "We're sorry. Our sign up system is currently down. Please try again later."
       },
+      "Welcome to E-library! This service is provided by your local library." : {
+         "string" : "Welcome to E-library! This service is provided by your local library."
+      },
       "Welcome to Open eBooks" : {
          "string" : "Welcome to Open eBooks"
       },
@@ -1217,6 +1232,9 @@
       },
       "You are at position %ld in the queue for this book." : {
          "string" : "You are at position %ld in the queue for this book."
+      },
+      "You can browse e-books and audiobooks by genre, book or author, or browse recommendation lists made by librarians." : {
+         "string" : "You can browse e-books and audiobooks by genre, book or author, or browse recommendation lists made by librarians."
       },
       "You can search for a book or an author using the search bar above.\n\nIf you want to search through all books, ensure you are on the Browse Books tab with 'All' selected." : {
          "string" : "You can search for a book or an author using the search bar above.\n\nIf you want to search through all books, ensure you are on the Browse Books tab with 'All' selected."
@@ -1649,6 +1667,9 @@
       "Browse Books" : {
          "string" : "Selaa"
       },
+      "Browse the selection, borrow and read or listen! If a book is on loan, press \"reserve\" to get it when it becomes available." : {
+         "string" : "Selaa valikoimaa, lainaa ja lue tai kuuntele! Jos kirja on lainassa, paina varaa, saat sen käyttöösi kun se vapautuu. "
+      },
       "By signing in, you agree the End User License Agreement" : {
          "string" : "Kirjautumalla sisään hyväksyt loppukäyttäjän lisenssisopimuksen"
       },
@@ -2045,6 +2066,9 @@
       "Opens audiobook %@ for listening" : {
          "string" : "Avaa äänikirjan %@ kuuntelua varten"
       },
+      "Or do you want something to listen to? The collection also includes an untold number of audiobooks! Click \"borrow\" to listen to the audiobook." : {
+         "string" : "Vai haluatko sittenkin kuunneltavaa? Kokoelmassa myös lukematon määrä äänikirjoja! Klikkaa lainaa ja pääset kuuntelemaan äänikirjan."
+      },
       "PDF" : {
          "string" : "PDF"
       },
@@ -2324,6 +2348,12 @@
       "Swedish" : {
          "string" : "ruotsi"
       },
+      "Swipe left for next page." : {
+         "string" : "Seuraava sivu pyyhkäisemällä vasemmalle."
+      },
+      "Swipe left to close tutorial." : {
+         "string" : "Sulje ohje pyyhkäisemällä vasemmalle."
+      },
       "Sync Bookmarks" : {
          "string" : "Synkronoi kirjanmerkit"
       },
@@ -2519,6 +2549,9 @@
       "We're sorry. Our sign up system is currently down. Please try again later." : {
          "string" : "Olemme pahoillamme. Kirjautumisjärjestelmämme on tällä hetkellä poissa käytöstä. Yritä myöhemmin uudelleen."
       },
+      "Welcome to E-library! This service is provided by your local library." : {
+         "string" : "Tervetuloa E-kirjastoon! Tämän palvelun sinulle tarjoaa kotikuntasi kirjasto."
+      },
       "Welcome to Open eBooks" : {
          "string" : "Tervetuloa Open eBooksiin"
       },
@@ -2545,6 +2578,9 @@
       },
       "You are at position %ld in the queue for this book." : {
          "string" : "Olet tämän kirjan varausjonossa sijalla %ld"
+      },
+      "You can browse e-books and audiobooks by genre, book or author, or browse recommendation lists made by librarians." : {
+         "string" : "Voit selata e- ja äänikirjoja lajeittain, kirjan tai kirjailijan mukaan tai tutkia kirjastolaisten tekemiä nostolistoja. "
       },
       "You can search for a book or an author using the search bar above.\n\nIf you want to search through all books, ensure you are on the Browse Books tab with 'All' selected." : {
          "string" : "Voit etsiä kirjaa tai kirjailijaa yllä olevan haun avulla.\n\nJos haluat kohdistaa haun kaikkiin kirjoihin, varmista, että olet Selaa-välilehdellä ja että 'Kaikki' on valittuna."
@@ -2977,6 +3013,9 @@
       "Browse Books" : {
          "string" : "Bläddra böcker"
       },
+      "Browse the selection, borrow and read or listen! If a book is on loan, press \"reserve\" to get it when it becomes available." : {
+         "string" : "Bläddra i urvalet, låna och läs eller lyssna! Om boken är utlånad, tryck på reservera för att få den när den blir tillgänglig."
+      },
       "By signing in, you agree the End User License Agreement" : {
          "string" : "Genom att logga in godkänner du slutanvändaravtalet"
       },
@@ -3373,6 +3412,9 @@
       "Opens audiobook %@ for listening" : {
          "string" : "Öppnar ljudboken %@ för att lyssna"
       },
+      "Or do you want something to listen to? The collection also includes an untold number of audiobooks! Click \"borrow\" to listen to the audiobook." : {
+         "string" : "Eller vill du sen också lyssna på något? I samlingen finns även ett otaligt antal ljudböcker! Klicka på låna så kommer du åt att lyssna på ljudboken. "
+      },
       "PDF" : {
          "string" : "PDF"
       },
@@ -3652,6 +3694,12 @@
       "Swedish" : {
          "string" : "svenska"
       },
+      "Swipe left for next page." : {
+         "string" : "Svep åt vänster för nästa sidan."
+      },
+      "Swipe left to close tutorial." : {
+         "string" : "Svep åt vänster för att stänga handledningen."
+      },
       "Sync Bookmarks" : {
          "string" : "Synkronisera bokmärken"
       },
@@ -3847,6 +3895,9 @@
       "We're sorry. Our sign up system is currently down. Please try again later." : {
          "string" : "Vi beklagar. Vårt registreringssystem ligger nere just nu. Försök på nytt senare."
       },
+      "Welcome to E-library! This service is provided by your local library." : {
+         "string" : "Välkommen till e-biblioteket! Denna tjänst erbjuds till dig av din hemkommuns biblioteket."
+      },
       "Welcome to Open eBooks" : {
          "string" : "Välkommen till Open eBooks"
       },
@@ -3873,6 +3924,9 @@
       },
       "You are at position %ld in the queue for this book." : {
          "string" : "Du är på plats %ld i kön till den här boken."
+      },
+      "You can browse e-books and audiobooks by genre, book or author, or browse recommendation lists made by librarians." : {
+         "string" : "Du kan bläddra bland e- och ljudböcker enligt genre, bok eller författare eller undersöka bibliotekspersonalens listor med verk de vill. "
       },
       "You can search for a book or an author using the search bar above.\n\nIf you want to search through all books, ensure you are on the Browse Books tab with 'All' selected." : {
          "string" : "Du kan söka efter en bok eller en författare med hjälp av sökfältet ovan.\n\nOm du vill rikta sökningen till alla böcker, se till att du är på fliken Bläddra böcker och att 'Alla' är valt."

--- a/Palace/Views/EkirjastoArrowDownButton.swift
+++ b/Palace/Views/EkirjastoArrowDownButton.swift
@@ -79,7 +79,7 @@ private let ButtonPadding: CGFloat = 6.0
     self.imageEdgeInsets = UIEdgeInsets(top: 1, left: 8, bottom: -1, right: -8)
     self.contentHorizontalAlignment = .trailing
     self.semanticContentAttribute = .forceRightToLeft
-    self.tintColor = UIColor(named: "ColorEkirjastoGreen")!
+    self.tintColor = UIColor(named: "ColorEkirjastoBlack")!
     titleLabel?.font = UIFont.boldPalaceFont(ofSize: 13)
   }
   

--- a/Palace/Views/TPPFacetView.m
+++ b/Palace/Views/TPPFacetView.m
@@ -127,9 +127,15 @@ CGFloat const toolbarHeight = 40;
 
 - (void)didSelectGroup:(UIButton *)sender
 {
+  //Add the name of the facet group to the top of the facets
+  //To indicate what we are choosing
+  //To match the swift implementation
+  NSString *title = [self.dataSource
+   facetView:self nameForFacetGroupAtIndex:sender.tag];
+  
   UIAlertController *const alertController =
     [UIAlertController
-     alertControllerWithTitle:nil
+     alertControllerWithTitle:title
      message:nil
      preferredStyle:UIAlertControllerStyleActionSheet];
   


### PR DESCRIPTION
**What's this do?**
This pr makes changes that better the accessibility of the application.

These changes include
- Bump ios-audiobooktoolkit to adjust audiobook player colors
- adjust search bar colors
- adjust audio descriptions for cover images, lane titles
- adjust colors for empty my books and favorites texts
- adjust cancel button color in tutorial page
- adjust arrow colors in all views
- add audio descriptions to the tutorial/onboarding images

**Why are we doing this? (w/ Notion link if applicable)**
Most tickets under 
https://jira.it.helsinki.fi/browse/EKIRJASTO-86

In addition
https://jira.it.helsinki.fi/browse/EKIRJASTO-469

**How should this be tested? / Do these changes have associated tests?**
All views should be checked in both light and dark mode. Only reader with changes is audiobook reader, so that should be checked in both colors. 
Search view should be checked in both modes.

Using screen reader, check the cover image audio description, as well as the lane title.

**Did someone actually run this code to verify it works?**
Ran on emulator and real device.

**Have the Transifex translators been notified?**

- [x] Translators informed
- [x] Translations done
