### PR TITLE
Migrate to Xcode 26 / iOS 26 with Liquid Glass theming

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,9 +1,3 @@
-[submodule "readium-sdk"]
-	path = readium-sdk
-	url = https://github.com/ThePalaceProject/mobile-readium-sdk
-[submodule "readium-shared-js"]
-	path = readium-shared-js
-	url = https://github.com/readium/readium-shared-js.git
 [submodule "ios-tenprintcover"]
 	path = ios-tenprintcover
 	url = https://github.com/ThePalaceProject/ios-tenprintcover.git

--- a/Palace.xcodeproj/project.pbxproj
+++ b/Palace.xcodeproj/project.pbxproj
@@ -79,7 +79,7 @@
 		11B6020519806CD300800DA9 /* TPPBookDownloadingCell.m in Sources */ = {isa = PBXBuildFile; fileRef = 11B6020419806CD300800DA9 /* TPPBookDownloadingCell.m */; };
 		11C113D019F842B9005B3F63 /* reader.html in Resources */ = {isa = PBXBuildFile; fileRef = 11C113CF19F842B9005B3F63 /* reader.html */; };
 		11C113D219F842BE005B3F63 /* host_app_feedback.js in Resources */ = {isa = PBXBuildFile; fileRef = 11C113D119F842BE005B3F63 /* host_app_feedback.js */; };
-		11C113D719F84613005B3F63 /* simplified.js in Resources */ = {isa = PBXBuildFile; fileRef = 11C113D519F84613005B3F63 /* simplified.js */; };
+		11C113D719F84613005B3F63 /* Simplified.js in Resources */ = {isa = PBXBuildFile; fileRef = 11C113D519F84613005B3F63 /* Simplified.js */; };
 		11C5DD16197727A6005A9945 /* TPPKeychain.m in Sources */ = {isa = PBXBuildFile; fileRef = 11C5DD15197727A6005A9945 /* TPPKeychain.m */; };
 		11E0208D197F05D9009DEA93 /* UIFont+TPPSystemFontOverride.m in Sources */ = {isa = PBXBuildFile; fileRef = 11E0208C197F05D9009DEA93 /* UIFont+TPPSystemFontOverride.m */; };
 		11F3771F19DB62B000487769 /* TPPFacetView.m in Sources */ = {isa = PBXBuildFile; fileRef = 11F3771E19DB62B000487769 /* TPPFacetView.m */; };
@@ -580,7 +580,7 @@
 		331264432A287F53006BA87D /* libxml2.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = 119503E61993F914009FB788 /* libxml2.dylib */; };
 		331264442A287F53006BA87D /* Minizip.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 2198690C267E29B00041369E /* Minizip.xcframework */; };
 		331264472A287F53006BA87D /* OFL.txt in Resources */ = {isa = PBXBuildFile; fileRef = 84B7A3431B84E8FE00584FB2 /* OFL.txt */; };
-		331264482A287F53006BA87D /* simplified.js in Resources */ = {isa = PBXBuildFile; fileRef = 11C113D519F84613005B3F63 /* simplified.js */; };
+		331264482A287F53006BA87D /* Simplified.js in Resources */ = {isa = PBXBuildFile; fileRef = 11C113D519F84613005B3F63 /* Simplified.js */; };
 		331264492A287F53006BA87D /* TPPProblemReportViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 085D31D81BE29ED4007F7672 /* TPPProblemReportViewController.xib */; };
 		3312644A2A287F53006BA87D /* OpenSans-Regular.ttf in Resources */ = {isa = PBXBuildFile; fileRef = E5BEEFF826BD919E00C2A50B /* OpenSans-Regular.ttf */; };
 		3312644D2A287F53006BA87D /* ReaderClientCert.sig in Resources */ = {isa = PBXBuildFile; fileRef = 085D31FB1BE7BE86007F7672 /* ReaderClientCert.sig */; };
@@ -981,7 +981,7 @@
 		73EB0B4525821DF4006BC997 /* libz.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = 119503E81993F919009FB788 /* libz.dylib */; };
 		73EB0B4625821DF4006BC997 /* libxml2.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = 119503E61993F914009FB788 /* libxml2.dylib */; };
 		73EB0B5925821DF4006BC997 /* OFL.txt in Resources */ = {isa = PBXBuildFile; fileRef = 84B7A3431B84E8FE00584FB2 /* OFL.txt */; };
-		73EB0B5A25821DF4006BC997 /* simplified.js in Resources */ = {isa = PBXBuildFile; fileRef = 11C113D519F84613005B3F63 /* simplified.js */; };
+		73EB0B5A25821DF4006BC997 /* Simplified.js in Resources */ = {isa = PBXBuildFile; fileRef = 11C113D519F84613005B3F63 /* Simplified.js */; };
 		73EB0B5B25821DF4006BC997 /* TPPProblemReportViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 085D31D81BE29ED4007F7672 /* TPPProblemReportViewController.xib */; };
 		73EB0B5D25821DF4006BC997 /* ReaderClientCert.sig in Resources */ = {isa = PBXBuildFile; fileRef = 085D31FB1BE7BE86007F7672 /* ReaderClientCert.sig */; };
 		73EB0B5E25821DF4006BC997 /* software-licenses.html in Resources */ = {isa = PBXBuildFile; fileRef = 2D6256901D41582A0080A81F /* software-licenses.html */; };
@@ -1647,7 +1647,7 @@
 		11B6020419806CD300800DA9 /* TPPBookDownloadingCell.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = TPPBookDownloadingCell.m; sourceTree = "<group>"; };
 		11C113CF19F842B9005B3F63 /* reader.html */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.html; path = reader.html; sourceTree = "<group>"; };
 		11C113D119F842BE005B3F63 /* host_app_feedback.js */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.javascript; path = host_app_feedback.js; sourceTree = "<group>"; };
-		11C113D519F84613005B3F63 /* simplified.js */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.javascript; path = simplified.js; sourceTree = "<group>"; };
+		11C113D519F84613005B3F63 /* Simplified.js */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.javascript; path = Simplified.js; sourceTree = "<group>"; };
 		11C5DD14197727A6005A9945 /* TPPKeychain.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TPPKeychain.h; sourceTree = "<group>"; };
 		11C5DD15197727A6005A9945 /* TPPKeychain.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = TPPKeychain.m; sourceTree = "<group>"; };
 		11C5DD171977335E005A9945 /* TPPKeychainTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = TPPKeychainTests.m; sourceTree = "<group>"; };
@@ -2355,7 +2355,7 @@
 			children = (
 				11C113D119F842BE005B3F63 /* host_app_feedback.js */,
 				11C113CF19F842B9005B3F63 /* reader.html */,
-				11C113D519F84613005B3F63 /* simplified.js */,
+				11C113D519F84613005B3F63 /* Simplified.js */,
 			);
 			name = Reader;
 			sourceTree = "<group>";
@@ -3537,13 +3537,6 @@
 			path = EkirjastoDigitalMagazine;
 			sourceTree = "<group>";
 		};
-		A49C25411AE05A2600D63B89 /* Products */ = {
-			isa = PBXGroup;
-			children = (
-			);
-			name = Products;
-			sourceTree = "<group>";
-		};
 		A823D804192BABA400B55DE2 = {
 			isa = PBXGroup;
 			children = (
@@ -4227,9 +4220,6 @@
 					ProjectRef = E553424F293FB23F004FF34A /* PalaceAudiobookToolkit.xcodeproj */;
 				},
 				{
-					ProductGroup = A49C25411AE05A2600D63B89 /* Products */;
-				},
-				{
 					ProductGroup = 1112A81A1A322C53002B8CC1 /* Products */;
 					ProjectRef = 1112A8191A322C53002B8CC1 /* TenPrintCover.xcodeproj */;
 				},
@@ -4355,7 +4345,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				331264472A287F53006BA87D /* OFL.txt in Resources */,
-				331264482A287F53006BA87D /* simplified.js in Resources */,
+				331264482A287F53006BA87D /* Simplified.js in Resources */,
 				331264492A287F53006BA87D /* TPPProblemReportViewController.xib in Resources */,
 				3312644A2A287F53006BA87D /* OpenSans-Regular.ttf in Resources */,
 				368EE7682BC5F82200663D37 /* PrivacyInfo.xcprivacy in Resources */,
@@ -4392,7 +4382,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				73EB0B5925821DF4006BC997 /* OFL.txt in Resources */,
-				73EB0B5A25821DF4006BC997 /* simplified.js in Resources */,
+				73EB0B5A25821DF4006BC997 /* Simplified.js in Resources */,
 				73EB0B5B25821DF4006BC997 /* TPPProblemReportViewController.xib in Resources */,
 				E5BEF00926BD919F00C2A50B /* OpenSans-Regular.ttf in Resources */,
 				73EB0B5D25821DF4006BC997 /* ReaderClientCert.sig in Resources */,
@@ -4422,7 +4412,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				84B7A3461B84E8FE00584FB2 /* OFL.txt in Resources */,
-				11C113D719F84613005B3F63 /* simplified.js in Resources */,
+				11C113D719F84613005B3F63 /* Simplified.js in Resources */,
 				085D31D91BE29ED4007F7672 /* TPPProblemReportViewController.xib in Resources */,
 				E5BEF00826BD919F00C2A50B /* OpenSans-Regular.ttf in Resources */,
 				2D4379FE1C46FDB600AE1AD5 /* ReaderClientCert.sig in Resources */,
@@ -5938,7 +5928,7 @@
 				CODE_SIGN_IDENTITY = "Apple Development";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = "10000";
+				CURRENT_PROJECT_VERSION = 10000;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = QA5XMCRV5M;
 				ENABLE_BITCODE = NO;
@@ -6002,7 +5992,7 @@
 				CODE_SIGN_IDENTITY = "Apple Development";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "Apple Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = "10000";
+				CURRENT_PROJECT_VERSION = 10000;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = 88CBA74T8K;
 				ENABLE_BITCODE = NO;
@@ -6062,7 +6052,7 @@
 				CODE_SIGN_ENTITLEMENTS = Palace/PalaceDebug.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = "10000";
+				CURRENT_PROJECT_VERSION = 10000;
 				DEVELOPMENT_TEAM = "";
 				ENABLE_BITCODE = NO;
 				FRAMEWORK_SEARCH_PATHS = (
@@ -6250,7 +6240,7 @@
 				CODE_SIGN_IDENTITY = "Apple Development";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = "10000";
+				CURRENT_PROJECT_VERSION = 10000;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = QA5XMCRV5M;
 				ENABLE_BITCODE = NO;
@@ -6314,7 +6304,7 @@
 				CODE_SIGN_IDENTITY = "Apple Development";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "Apple Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = "10000";
+				CURRENT_PROJECT_VERSION = 10000;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = 88CBA74T8K;
 				ENABLE_BITCODE = NO;
@@ -6374,7 +6364,7 @@
 				CODE_SIGN_ENTITLEMENTS = Palace/PalaceDebug.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = "10000";
+				CURRENT_PROJECT_VERSION = 10000;
 				DEVELOPMENT_TEAM = "";
 				ENABLE_BITCODE = NO;
 				FRAMEWORK_SEARCH_PATHS = (
@@ -6562,7 +6552,7 @@
 				CODE_SIGN_IDENTITY = "Apple Development";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = "10000";
+				CURRENT_PROJECT_VERSION = 10000;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = QA5XMCRV5M;
 				ENABLE_BITCODE = NO;
@@ -6626,7 +6616,7 @@
 				CODE_SIGN_IDENTITY = "Apple Development";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "Apple Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = "10000";
+				CURRENT_PROJECT_VERSION = 10000;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = 88CBA74T8K;
 				ENABLE_BITCODE = NO;
@@ -6686,7 +6676,7 @@
 				CODE_SIGN_ENTITLEMENTS = Palace/PalaceDebug.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = "10000";
+				CURRENT_PROJECT_VERSION = 10000;
 				DEVELOPMENT_TEAM = "";
 				ENABLE_BITCODE = NO;
 				FRAMEWORK_SEARCH_PATHS = (
@@ -6874,7 +6864,7 @@
 				CODE_SIGN_IDENTITY = "Apple Development";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = "10000";
+				CURRENT_PROJECT_VERSION = 10000;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = QA5XMCRV5M;
 				ENABLE_BITCODE = NO;
@@ -6938,7 +6928,7 @@
 				CODE_SIGN_IDENTITY = "Apple Development";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "Apple Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = "10000";
+				CURRENT_PROJECT_VERSION = 10000;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = 88CBA74T8K;
 				ENABLE_BITCODE = NO;
@@ -6998,7 +6988,7 @@
 				CODE_SIGN_ENTITLEMENTS = Palace/PalaceDebug.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = "10000";
+				CURRENT_PROJECT_VERSION = 10000;
 				DEVELOPMENT_TEAM = "";
 				ENABLE_BITCODE = NO;
 				FRAMEWORK_SEARCH_PATHS = (
@@ -7182,7 +7172,7 @@
 				CODE_SIGN_IDENTITY = "Apple Development";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = "10000";
+				CURRENT_PROJECT_VERSION = 10000;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = QA5XMCRV5M;
 				ENABLE_BITCODE = NO;
@@ -7243,7 +7233,7 @@
 				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES_ERROR;
 				CODE_SIGN_ENTITLEMENTS = Palace/SimplyE.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Distribution";
-				CURRENT_PROJECT_VERSION = "10000";
+				CURRENT_PROJECT_VERSION = 10000;
 				DEVELOPMENT_TEAM = 88CBA74T8K;
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = 88CBA74T8K;
 				ENABLE_BITCODE = NO;
@@ -7302,7 +7292,7 @@
 				CODE_SIGN_ENTITLEMENTS = Palace/SimplyE.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = "10000";
+				CURRENT_PROJECT_VERSION = 10000;
 				DEVELOPMENT_TEAM = 88CBA74T8K;
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = 88CBA74T8K;
 				ENABLE_BITCODE = NO;
@@ -7483,7 +7473,7 @@
 				CODE_SIGN_IDENTITY = "Apple Development";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = "10000";
+				CURRENT_PROJECT_VERSION = 10000;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = QA5XMCRV5M;
 				ENABLE_BITCODE = NO;
@@ -7544,7 +7534,7 @@
 				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES_ERROR;
 				CODE_SIGN_ENTITLEMENTS = Palace/SimplyE.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Distribution";
-				CURRENT_PROJECT_VERSION = "10000";
+				CURRENT_PROJECT_VERSION = 10000;
 				DEVELOPMENT_TEAM = 88CBA74T8K;
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = 88CBA74T8K;
 				ENABLE_BITCODE = NO;
@@ -7603,7 +7593,7 @@
 				CODE_SIGN_ENTITLEMENTS = Palace/SimplyE.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = "10000";
+				CURRENT_PROJECT_VERSION = 10000;
 				DEVELOPMENT_TEAM = 88CBA74T8K;
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = 88CBA74T8K;
 				ENABLE_BITCODE = NO;
@@ -7784,7 +7774,7 @@
 				CODE_SIGN_IDENTITY = "Apple Development";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = "10000";
+				CURRENT_PROJECT_VERSION = 10000;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = QA5XMCRV5M;
 				ENABLE_BITCODE = NO;
@@ -7845,7 +7835,7 @@
 				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES_ERROR;
 				CODE_SIGN_ENTITLEMENTS = Palace/SimplyE.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Distribution";
-				CURRENT_PROJECT_VERSION = "10000";
+				CURRENT_PROJECT_VERSION = 10000;
 				DEVELOPMENT_TEAM = 88CBA74T8K;
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = 88CBA74T8K;
 				ENABLE_BITCODE = NO;
@@ -7904,7 +7894,7 @@
 				CODE_SIGN_ENTITLEMENTS = Palace/SimplyE.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = "10000";
+				CURRENT_PROJECT_VERSION = 10000;
 				DEVELOPMENT_TEAM = 88CBA74T8K;
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = 88CBA74T8K;
 				ENABLE_BITCODE = NO;
@@ -8085,7 +8075,7 @@
 				CODE_SIGN_IDENTITY = "Apple Development";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = "10000";
+				CURRENT_PROJECT_VERSION = 10000;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = QA5XMCRV5M;
 				ENABLE_BITCODE = NO;
@@ -8146,7 +8136,7 @@
 				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES_ERROR;
 				CODE_SIGN_ENTITLEMENTS = Palace/SimplyE.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Distribution";
-				CURRENT_PROJECT_VERSION = "10000";
+				CURRENT_PROJECT_VERSION = 10000;
 				DEVELOPMENT_TEAM = 88CBA74T8K;
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = 88CBA74T8K;
 				ENABLE_BITCODE = NO;
@@ -8205,7 +8195,7 @@
 				CODE_SIGN_ENTITLEMENTS = Palace/SimplyE.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = "10000";
+				CURRENT_PROJECT_VERSION = 10000;
 				DEVELOPMENT_TEAM = 88CBA74T8K;
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = 88CBA74T8K;
 				ENABLE_BITCODE = NO;
@@ -8452,7 +8442,7 @@
 				CODE_SIGN_IDENTITY = "Apple Development";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = "10000";
+				CURRENT_PROJECT_VERSION = 10000;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = QA5XMCRV5M;
 				ENABLE_BITCODE = NO;
@@ -8514,7 +8504,7 @@
 				CODE_SIGN_IDENTITY = "Apple Development";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = "10000";
+				CURRENT_PROJECT_VERSION = 10000;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = QA5XMCRV5M;
 				ENABLE_BITCODE = NO;
@@ -8574,7 +8564,7 @@
 				CODE_SIGN_ENTITLEMENTS = Palace/PalaceDebug.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = "10000";
+				CURRENT_PROJECT_VERSION = 10000;
 				DEVELOPMENT_TEAM = "";
 				ENABLE_BITCODE = NO;
 				FRAMEWORK_SEARCH_PATHS = (
@@ -8631,7 +8621,7 @@
 				CODE_SIGN_ENTITLEMENTS = Palace/SimplyE.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = "10000";
+				CURRENT_PROJECT_VERSION = 10000;
 				DEVELOPMENT_TEAM = 88CBA74T8K;
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = 88CBA74T8K;
 				ENABLE_BITCODE = NO;
@@ -8816,7 +8806,7 @@
 				CODE_SIGN_IDENTITY = "Apple Development";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "Apple Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = "10000";
+				CURRENT_PROJECT_VERSION = 10000;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = 88CBA74T8K;
 				ENABLE_BITCODE = NO;
@@ -8876,7 +8866,7 @@
 				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES_ERROR;
 				CODE_SIGN_ENTITLEMENTS = Palace/SimplyE.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Distribution";
-				CURRENT_PROJECT_VERSION = "10000";
+				CURRENT_PROJECT_VERSION = 10000;
 				DEVELOPMENT_TEAM = 88CBA74T8K;
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = 88CBA74T8K;
 				ENABLE_BITCODE = NO;

--- a/Palace.xcodeproj/project.pbxproj
+++ b/Palace.xcodeproj/project.pbxproj
@@ -36,7 +36,6 @@
 		08A352221BDE8E560040BF1D /* libicucore.tbd in Frameworks */ = {isa = PBXBuildFile; fileRef = 08A352211BDE8E560040BF1D /* libicucore.tbd */; };
 		08A352241BDE8E640040BF1D /* Security.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 08A352231BDE8E640040BF1D /* Security.framework */; };
 		08A352261BDE8E700040BF1D /* SystemConfiguration.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 08A352251BDE8E700040BF1D /* SystemConfiguration.framework */; };
-		08A352271BDE91B80040BF1D /* libRDServices.a in Frameworks */ = {isa = PBXBuildFile; fileRef = A49C25461AE05A2600D63B89 /* libRDServices.a */; };
 		08C469C11BDAAEB1009D8AFD /* libADEPT.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 5A569A2C1B8351C6003B5B61 /* libADEPT.a */; settings = {ATTRIBUTES = (Weak, ); }; };
 		11068C55196DD37900E8A94B /* TPPNull.m in Sources */ = {isa = PBXBuildFile; fileRef = 11068C54196DD37900E8A94B /* TPPNull.m */; };
 		11078357198160A50071AB1E /* TPPBookDownloadFailedCell.m in Sources */ = {isa = PBXBuildFile; fileRef = 11078356198160A50071AB1E /* TPPBookDownloadFailedCell.m */; };
@@ -562,7 +561,6 @@
 		331264262A287F53006BA87D /* libiconv.tbd in Frameworks */ = {isa = PBXBuildFile; fileRef = 03B092251E7883C400AD338D /* libiconv.tbd */; };
 		331264282A287F53006BA87D /* CoreGraphics.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A823D812192BABA400B55DE2 /* CoreGraphics.framework */; };
 		331264292A287F53006BA87D /* QuartzCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 03B092231E78839D00AD338D /* QuartzCore.framework */; };
-		3312642B2A287F53006BA87D /* libRDServices.a in Frameworks */ = {isa = PBXBuildFile; fileRef = A49C25461AE05A2600D63B89 /* libRDServices.a */; };
 		3312642C2A287F53006BA87D /* R2Navigator in Frameworks */ = {isa = PBXBuildFile; productRef = 331262D42A287F53006BA87D /* R2Navigator */; };
 		3312642D2A287F53006BA87D /* libicucore.tbd in Frameworks */ = {isa = PBXBuildFile; fileRef = 08A352211BDE8E560040BF1D /* libicucore.tbd */; };
 		3312642F2A287F53006BA87D /* SQLite in Frameworks */ = {isa = PBXBuildFile; productRef = 331262DA2A287F53006BA87D /* SQLite */; };
@@ -585,7 +583,6 @@
 		331264482A287F53006BA87D /* simplified.js in Resources */ = {isa = PBXBuildFile; fileRef = 11C113D519F84613005B3F63 /* simplified.js */; };
 		331264492A287F53006BA87D /* TPPProblemReportViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 085D31D81BE29ED4007F7672 /* TPPProblemReportViewController.xib */; };
 		3312644A2A287F53006BA87D /* OpenSans-Regular.ttf in Resources */ = {isa = PBXBuildFile; fileRef = E5BEEFF826BD919E00C2A50B /* OpenSans-Regular.ttf */; };
-		3312644C2A287F53006BA87D /* readium-shared-js_all.js in Resources */ = {isa = PBXBuildFile; fileRef = 5A69290D1B95ACC600FB4C10 /* readium-shared-js_all.js */; };
 		3312644D2A287F53006BA87D /* ReaderClientCert.sig in Resources */ = {isa = PBXBuildFile; fileRef = 085D31FB1BE7BE86007F7672 /* ReaderClientCert.sig */; };
 		3312644E2A287F53006BA87D /* Localizable.stringsdict in Resources */ = {isa = PBXBuildFile; fileRef = 17E81F32261FF758001003C2 /* Localizable.stringsdict */; };
 		3312644F2A287F53006BA87D /* software-licenses.html in Resources */ = {isa = PBXBuildFile; fileRef = 2D6256901D41582A0080A81F /* software-licenses.html */; };
@@ -594,14 +591,11 @@
 		331264532A287F53006BA87D /* OpenSans-Bold.ttf in Resources */ = {isa = PBXBuildFile; fileRef = E5BEEFF526BD919D00C2A50B /* OpenSans-Bold.ttf */; };
 		331264542A287F53006BA87D /* reader.html in Resources */ = {isa = PBXBuildFile; fileRef = 11C113CF19F842B9005B3F63 /* reader.html */; };
 		331264552A287F53006BA87D /* DetailSummaryTemplate.html in Resources */ = {isa = PBXBuildFile; fileRef = 110F853C19D5FA7300052DF7 /* DetailSummaryTemplate.html */; };
-		331264592A287F53006BA87D /* sdk.css in Resources */ = {isa = PBXBuildFile; fileRef = 5A69290F1B95ACD100FB4C10 /* sdk.css */; };
 		3312645A2A287F53006BA87D /* OpenSans-SemiBold.ttf in Resources */ = {isa = PBXBuildFile; fileRef = E5BEF01C26BDA9EA00C2A50B /* OpenSans-SemiBold.ttf */; };
 		3312645B2A287F53006BA87D /* OpenDyslexic3-Bold.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 84B7A3441B84E8FE00584FB2 /* OpenDyslexic3-Bold.ttf */; };
-		3312645C2A287F53006BA87D /* readium-shared-js_all.js.map in Resources */ = {isa = PBXBuildFile; fileRef = 5A69291D1B95C8AD00FB4C10 /* readium-shared-js_all.js.map */; };
 		3312645E2A287F53006BA87D /* TPPReaderPositions.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 7335BA9A2453C48F000295F2 /* TPPReaderPositions.storyboard */; };
 		3312645F2A287F53006BA87D /* host_app_feedback.js in Resources */ = {isa = PBXBuildFile; fileRef = 11C113D119F842BE005B3F63 /* host_app_feedback.js */; };
 		331264612A287F53006BA87D /* txstrings.json in Resources */ = {isa = PBXBuildFile; fileRef = E5D32881292C0D34008BFD01 /* txstrings.json */; };
-		331264622A287F53006BA87D /* readium-shared-js_all.js.bundles.js in Resources */ = {isa = PBXBuildFile; fileRef = 5A6929231B95C8B400FB4C10 /* readium-shared-js_all.js.bundles.js */; };
 		331264632A287F53006BA87D /* OpenDyslexic3-Regular.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 84B7A3451B84E8FE00584FB2 /* OpenDyslexic3-Regular.ttf */; };
 		331264682A287F53006BA87D /* (null) in Embed Frameworks */ = {isa = PBXBuildFile; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		331264692A287F53006BA87D /* PureLayout.xcframework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 21986921267E29D70041369E /* PureLayout.xcframework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
@@ -690,10 +684,6 @@
 		36BBC7922B920EB300E8E426 /* EkirjastoSuomiIdentificationWebView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33C1160E2AE7A914007CABEB /* EkirjastoSuomiIdentificationWebView.swift */; };
 		36BBC7932B920EE100E8E426 /* PasskeyManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 36833E4B2B5E937000D7B6B2 /* PasskeyManager.swift */; };
 		52592BB821220A1100587288 /* TPPLocalization.m in Sources */ = {isa = PBXBuildFile; fileRef = 52592BB721220A1100587288 /* TPPLocalization.m */; };
-		5A69290E1B95ACC600FB4C10 /* readium-shared-js_all.js in Resources */ = {isa = PBXBuildFile; fileRef = 5A69290D1B95ACC600FB4C10 /* readium-shared-js_all.js */; };
-		5A6929101B95ACD100FB4C10 /* sdk.css in Resources */ = {isa = PBXBuildFile; fileRef = 5A69290F1B95ACD100FB4C10 /* sdk.css */; };
-		5A6929241B95C8B400FB4C10 /* readium-shared-js_all.js.bundles.js in Resources */ = {isa = PBXBuildFile; fileRef = 5A6929231B95C8B400FB4C10 /* readium-shared-js_all.js.bundles.js */; };
-		5A6929251B95C93B00FB4C10 /* readium-shared-js_all.js.map in Resources */ = {isa = PBXBuildFile; fileRef = 5A69291D1B95C8AD00FB4C10 /* readium-shared-js_all.js.map */; };
 		5AEA9E011B947419009F71DB /* libc++.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = 119503EA1993F91E009FB788 /* libc++.dylib */; };
 		5D1B141522CBE3570006C964 /* TPPProblemDocument.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5D1B141422CBE3570006C964 /* TPPProblemDocument.swift */; };
 		5D1B142A22CC179F0006C964 /* TPPAlertUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5D1B142922CC179F0006C964 /* TPPAlertUtils.swift */; };
@@ -978,7 +968,6 @@
 		73EB0B3325821DF4006BC997 /* libiconv.tbd in Frameworks */ = {isa = PBXBuildFile; fileRef = 03B092251E7883C400AD338D /* libiconv.tbd */; };
 		73EB0B3425821DF4006BC997 /* CoreGraphics.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A823D812192BABA400B55DE2 /* CoreGraphics.framework */; };
 		73EB0B3525821DF4006BC997 /* QuartzCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 03B092231E78839D00AD338D /* QuartzCore.framework */; };
-		73EB0B3825821DF4006BC997 /* libRDServices.a in Frameworks */ = {isa = PBXBuildFile; fileRef = A49C25461AE05A2600D63B89 /* libRDServices.a */; };
 		73EB0B3925821DF4006BC997 /* libicucore.tbd in Frameworks */ = {isa = PBXBuildFile; fileRef = 08A352211BDE8E560040BF1D /* libicucore.tbd */; };
 		73EB0B3A25821DF4006BC997 /* libc++.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = 119503EA1993F91E009FB788 /* libc++.dylib */; };
 		73EB0B3B25821DF4006BC997 /* LocalAuthentication.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 2DA4F2321C68363B008853D7 /* LocalAuthentication.framework */; };
@@ -994,7 +983,6 @@
 		73EB0B5925821DF4006BC997 /* OFL.txt in Resources */ = {isa = PBXBuildFile; fileRef = 84B7A3431B84E8FE00584FB2 /* OFL.txt */; };
 		73EB0B5A25821DF4006BC997 /* simplified.js in Resources */ = {isa = PBXBuildFile; fileRef = 11C113D519F84613005B3F63 /* simplified.js */; };
 		73EB0B5B25821DF4006BC997 /* TPPProblemReportViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 085D31D81BE29ED4007F7672 /* TPPProblemReportViewController.xib */; };
-		73EB0B5C25821DF4006BC997 /* readium-shared-js_all.js in Resources */ = {isa = PBXBuildFile; fileRef = 5A69290D1B95ACC600FB4C10 /* readium-shared-js_all.js */; };
 		73EB0B5D25821DF4006BC997 /* ReaderClientCert.sig in Resources */ = {isa = PBXBuildFile; fileRef = 085D31FB1BE7BE86007F7672 /* ReaderClientCert.sig */; };
 		73EB0B5E25821DF4006BC997 /* software-licenses.html in Resources */ = {isa = PBXBuildFile; fileRef = 2D6256901D41582A0080A81F /* software-licenses.html */; };
 		73EB0B6025821DF4006BC997 /* Accounts.json in Resources */ = {isa = PBXBuildFile; fileRef = 03F94CCE1DD627AA00CE8F4F /* Accounts.json */; };
@@ -1002,11 +990,8 @@
 		73EB0B6225821DF4006BC997 /* reader.html in Resources */ = {isa = PBXBuildFile; fileRef = 11C113CF19F842B9005B3F63 /* reader.html */; };
 		73EB0B6325821DF4006BC997 /* DetailSummaryTemplate.html in Resources */ = {isa = PBXBuildFile; fileRef = 110F853C19D5FA7300052DF7 /* DetailSummaryTemplate.html */; };
 		73EB0B6525821DF4006BC997 /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = A823D822192BABA400B55DE2 /* Images.xcassets */; };
-		73EB0B6625821DF4006BC997 /* sdk.css in Resources */ = {isa = PBXBuildFile; fileRef = 5A69290F1B95ACD100FB4C10 /* sdk.css */; };
 		73EB0B6725821DF4006BC997 /* OpenDyslexic3-Bold.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 84B7A3441B84E8FE00584FB2 /* OpenDyslexic3-Bold.ttf */; };
-		73EB0B6925821DF4006BC997 /* readium-shared-js_all.js.map in Resources */ = {isa = PBXBuildFile; fileRef = 5A69291D1B95C8AD00FB4C10 /* readium-shared-js_all.js.map */; };
 		73EB0B6A25821DF4006BC997 /* host_app_feedback.js in Resources */ = {isa = PBXBuildFile; fileRef = 11C113D119F842BE005B3F63 /* host_app_feedback.js */; };
-		73EB0B6B25821DF4006BC997 /* readium-shared-js_all.js.bundles.js in Resources */ = {isa = PBXBuildFile; fileRef = 5A6929231B95C8B400FB4C10 /* readium-shared-js_all.js.bundles.js */; };
 		73EB0B6C25821DF4006BC997 /* OpenDyslexic3-Regular.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 84B7A3451B84E8FE00584FB2 /* OpenDyslexic3-Regular.ttf */; };
 		73EB0B6D25821DF4006BC997 /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = 738EF2CB2405E38800F388FB /* GoogleService-Info.plist */; };
 		73F36BD825CC76C60057954C /* XCTest.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 73F36BD325CC76C60057954C /* XCTest.framework */; };
@@ -1218,7 +1203,6 @@
 		E5824BE32994B29700DE76C2 /* ButtonView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E5824BE22994B29700DE76C2 /* ButtonView.swift */; };
 		E5824BF129988C4E00DE76C2 /* TPPSAMLHelper.m in Sources */ = {isa = PBXBuildFile; fileRef = 730263AB2540DE4200A53891 /* TPPSAMLHelper.m */; };
 		E5824BF229988C4F00DE76C2 /* TPPSAMLHelper.m in Sources */ = {isa = PBXBuildFile; fileRef = 730263AB2540DE4200A53891 /* TPPSAMLHelper.m */; };
-		E58565CF269774C400A5FBD5 /* AudioEngine.xcframework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = E58565CE269774C400A5FBD5 /* AudioEngine.xcframework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		E58C330A2AD98F61005C44A2 /* EPUBSearchViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = E57345502AD6EB600021D768 /* EPUBSearchViewModel.swift */; };
 		E59526EB28D24FC000C179DA /* AudiobookSample.swift in Sources */ = {isa = PBXBuildFile; fileRef = E59526EA28D24FC000C179DA /* AudiobookSample.swift */; };
 		E59892E128A9AC2600C44A85 /* Sample.swift in Sources */ = {isa = PBXBuildFile; fileRef = E59892E028A9AC2600C44A85 /* Sample.swift */; };
@@ -1449,13 +1433,6 @@
 			remoteGlobalIDString = A4FD2F3A1B601DDA0013DF4F;
 			remoteInfo = ADEPT;
 		};
-		A49C25451AE05A2600D63B89 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = A49C25401AE05A2600D63B89 /* RDServices.xcodeproj */;
-			proxyType = 2;
-			remoteGlobalIDString = 118A0E281992B3FD00792DDE;
-			remoteInfo = RDServices;
-		};
 		E585662426979AC100A5FBD5 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = E585662026979AC100A5FBD5 /* NYPLAEToolkit.xcodeproj */;
@@ -1507,7 +1484,6 @@
 			dstPath = "";
 			dstSubfolderSpec = 10;
 			files = (
-				E58565CF269774C400A5FBD5 /* AudioEngine.xcframework in Embed Frameworks */,
 				E7F2877A2956566900EEB1E0 /* R2LCPClient.xcframework in Embed Frameworks */,
 				21986923267E29D70041369E /* PureLayout.xcframework in Embed Frameworks */,
 				2198690E267E29B00041369E /* Minizip.xcframework in Embed Frameworks */,
@@ -1651,7 +1627,6 @@
 		118A0B1A19915BDF00792DDE /* TPPCatalogSearchViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = TPPCatalogSearchViewController.m; sourceTree = "<group>"; };
 		118B7ABD195CBF72005CE3E7 /* TPPSession.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TPPSession.h; sourceTree = "<group>"; };
 		118B7ABE195CBF72005CE3E7 /* TPPSession.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = TPPSession.m; sourceTree = "<group>"; };
-		119503E41993F90C009FB788 /* libePub3-iOS.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = "libePub3-iOS.a"; path = "readium-sdk/Platform/Apple/build/Debug-iphoneos/libePub3-iOS.a"; sourceTree = "<group>"; };
 		119503E61993F914009FB788 /* libxml2.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = libxml2.dylib; path = usr/lib/libxml2.dylib; sourceTree = SDKROOT; };
 		119503E81993F919009FB788 /* libz.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = libz.dylib; path = usr/lib/libz.dylib; sourceTree = SDKROOT; };
 		119503EA1993F91E009FB788 /* libc++.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = "libc++.dylib"; path = "usr/lib/libc++.dylib"; sourceTree = SDKROOT; };
@@ -1689,14 +1664,7 @@
 		11F54C2619410C700086FCAF /* NYPLOPDSEntryTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = NYPLOPDSEntryTests.m; sourceTree = "<group>"; };
 		11F54C2919423A040086FCAF /* NYPLOPDSLinkTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = NYPLOPDSLinkTests.m; sourceTree = "<group>"; };
 		145798F5215BE9E300F68AFD /* ProblemReportEmail.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProblemReportEmail.swift; sourceTree = "<group>"; };
-		145DA48D215441A70055DB93 /* ZXingObjC.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = ZXingObjC.framework; path = Carthage/Build/iOS/ZXingObjC.framework; sourceTree = "<group>"; };
-		145DA4912154464F0055DB93 /* SQLite.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SQLite.framework; path = Carthage/Build/iOS/SQLite.framework; sourceTree = "<group>"; };
-		145DA49321544A3F0055DB93 /* NYPLCardCreator.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = NYPLCardCreator.framework; path = Carthage/Build/iOS/NYPLCardCreator.framework; sourceTree = "<group>"; };
-		145DA49521544A420055DB93 /* PureLayout.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = PureLayout.framework; path = Carthage/Build/iOS/PureLayout.framework; sourceTree = "<group>"; };
-		148B1C1721710C6800FF64AB /* NYPLAEToolkit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = NYPLAEToolkit.framework; path = Carthage/Build/iOS/NYPLAEToolkit.framework; sourceTree = "<group>"; };
-		148B1C1C21710C6800FF64AB /* NYPLAudiobookToolkit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = NYPLAudiobookToolkit.framework; path = Carthage/Build/iOS/NYPLAudiobookToolkit.framework; sourceTree = "<group>"; };
 		17071060242A923400E2648F /* TPPSecrets.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TPPSecrets.swift; sourceTree = "<group>"; };
-		170E5FBD25AFDD64007D6DE6 /* ZIPFoundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = ZIPFoundation.framework; path = Carthage/Build/iOS/ZIPFoundation.framework; sourceTree = "<group>"; };
 		171966A824170819007BB87E /* TPPBookState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TPPBookState.swift; sourceTree = "<group>"; };
 		173F0822241AAA4E00A64658 /* TPPBookStateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TPPBookStateTests.swift; sourceTree = "<group>"; };
 		175E480724EF36520066A6CF /* TPPAnnouncementBusinessLogic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TPPAnnouncementBusinessLogic.swift; sourceTree = "<group>"; };
@@ -1712,7 +1680,6 @@
 		17BE24EC25FB09F000AE707F /* TPPCurrentLibraryAccountProviderMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TPPCurrentLibraryAccountProviderMock.swift; sourceTree = "<group>"; };
 		17BE24EE25FB114900AE707F /* simplye_authentication_document.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = simplye_authentication_document.json; sourceTree = "<group>"; };
 		17CE5304243C020800315E63 /* TPPUserAccount.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TPPUserAccount.swift; sourceTree = "<group>"; };
-		17D08378248E8EEB00092AA9 /* OverdriveProcessor.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = OverdriveProcessor.framework; path = Carthage/Build/iOS/OverdriveProcessor.framework; sourceTree = "<group>"; };
 		17E81F07261522B3001003C2 /* TPPRoundedButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TPPRoundedButton.swift; sourceTree = "<group>"; };
 		17E81F31261FF758001003C2 /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.stringsdict; name = en; path = en.lproj/Localizable.stringsdict; sourceTree = "<group>"; };
 		21045C542761092C00D2D407 /* TPPOnboardingViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TPPOnboardingViewController.swift; sourceTree = "<group>"; };
@@ -1720,38 +1687,14 @@
 		2126FE2D25C059240095C45C /* ReaderError.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ReaderError.swift; sourceTree = "<group>"; };
 		212B99D2258A36FD00C8BF79 /* LCPAudiobooks.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LCPAudiobooks.swift; sourceTree = "<group>"; };
 		21562CC2276BB52700C03372 /* AdobeDRMAlerts.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AdobeDRMAlerts.swift; sourceTree = "<group>"; };
-		2156B54425B200EA003AD8EC /* R2LCPClient.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = R2LCPClient.framework; path = Carthage/Build/iOS/R2LCPClient.framework; sourceTree = "<group>"; };
-		2156B54625B200F6003AD8EC /* ReadiumLCP.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = ReadiumLCP.framework; path = Carthage/Build/iOS/ReadiumLCP.framework; sourceTree = "<group>"; };
 		215C866C27064198005F9621 /* BundleExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BundleExtension.swift; sourceTree = "<group>"; };
 		216D2E38274286D200472538 /* TPPLCPLicense.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TPPLCPLicense.swift; sourceTree = "<group>"; };
 		2171ADA0251E38140003CABA /* LCPLibraryService.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LCPLibraryService.swift; sourceTree = "<group>"; };
 		217595D927B6800100BA0FDD /* TPPReaderSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TPPReaderSettingsView.swift; sourceTree = "<group>"; };
 		217595DC27B680D400BA0FDD /* TPPReaderSettingsVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TPPReaderSettingsVC.swift; sourceTree = "<group>"; };
 		219747F626D9218400FA25DF /* TPPLCPClient.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TPPLCPClient.swift; sourceTree = "<group>"; };
-		219868F6267E29830041369E /* CryptoSwift.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = CryptoSwift.xcframework; path = Carthage/Build/CryptoSwift.xcframework; sourceTree = "<group>"; };
-		219868FE267E29920041369E /* Fuzi.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = Fuzi.xcframework; path = Carthage/Build/Fuzi.xcframework; sourceTree = "<group>"; };
-		21986905267E299E0041369E /* GCDWebServer.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = GCDWebServer.xcframework; path = Carthage/Build/GCDWebServer.xcframework; sourceTree = "<group>"; };
 		2198690C267E29B00041369E /* Minizip.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = Minizip.xcframework; path = Carthage/Build/Minizip.xcframework; sourceTree = "<group>"; };
-		21986913267E29BC0041369E /* NYPLAudiobookToolkit.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = NYPLAudiobookToolkit.xcframework; path = Carthage/Build/NYPLAudiobookToolkit.xcframework; sourceTree = "<group>"; };
-		2198691A267E29CC0041369E /* PDFRendererProvider.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = PDFRendererProvider.xcframework; path = Carthage/Build/PDFRendererProvider.xcframework; sourceTree = "<group>"; };
 		21986921267E29D70041369E /* PureLayout.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = PureLayout.xcframework; path = Carthage/Build/PureLayout.xcframework; sourceTree = "<group>"; };
-		21986928267E29EA0041369E /* R2Navigator.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = R2Navigator.xcframework; path = Carthage/Build/R2Navigator.xcframework; sourceTree = "<group>"; };
-		2198692D267E29EE0041369E /* R2Shared.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = R2Shared.xcframework; path = Carthage/Build/R2Shared.xcframework; sourceTree = "<group>"; };
-		21986932267E29F30041369E /* R2Streamer.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = R2Streamer.xcframework; path = Carthage/Build/R2Streamer.xcframework; sourceTree = "<group>"; };
-		21986939267E2A030041369E /* SQLite.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = SQLite.xcframework; path = Carthage/Build/SQLite.xcframework; sourceTree = "<group>"; };
-		21986940267E2A0A0041369E /* SwiftSoup.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = SwiftSoup.xcframework; path = Carthage/Build/SwiftSoup.xcframework; sourceTree = "<group>"; };
-		21986947267E2A120041369E /* ZIPFoundation.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = ZIPFoundation.xcframework; path = Carthage/Build/ZIPFoundation.xcframework; sourceTree = "<group>"; };
-		2198694C267E2A140041369E /* ZXingObjC.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = ZXingObjC.xcframework; path = Carthage/Build/ZXingObjC.xcframework; sourceTree = "<group>"; };
-		21986998267E78FC0041369E /* FirebaseCrashlytics.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = FirebaseCrashlytics.xcframework; path = Carthage/Build/FirebaseCrashlytics.xcframework; sourceTree = "<group>"; };
-		21986999267E78FC0041369E /* FirebaseAnalytics.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = FirebaseAnalytics.xcframework; path = Carthage/Build/FirebaseAnalytics.xcframework; sourceTree = "<group>"; };
-		2198699A267E78FC0041369E /* FirebaseInstallations.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = FirebaseInstallations.xcframework; path = Carthage/Build/FirebaseInstallations.xcframework; sourceTree = "<group>"; };
-		2198699B267E78FC0041369E /* FirebaseCore.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = FirebaseCore.xcframework; path = Carthage/Build/FirebaseCore.xcframework; sourceTree = "<group>"; };
-		2198699C267E78FD0041369E /* FirebaseCoreDiagnostics.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = FirebaseCoreDiagnostics.xcframework; path = Carthage/Build/FirebaseCoreDiagnostics.xcframework; sourceTree = "<group>"; };
-		219869CD267E80800041369E /* GoogleDataTransport.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = GoogleDataTransport.xcframework; path = Carthage/Build/GoogleDataTransport.xcframework; sourceTree = "<group>"; };
-		219869CE267E80800041369E /* GoogleAppMeasurement.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = GoogleAppMeasurement.xcframework; path = Carthage/Build/GoogleAppMeasurement.xcframework; sourceTree = "<group>"; };
-		219869CF267E80800041369E /* nanopb.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = nanopb.xcframework; path = Carthage/Build/nanopb.xcframework; sourceTree = "<group>"; };
-		219869D0267E80800041369E /* GoogleUtilities.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = GoogleUtilities.xcframework; path = Carthage/Build/GoogleUtilities.xcframework; sourceTree = "<group>"; };
-		219869D1267E80800041369E /* PromisesObjC.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = PromisesObjC.xcframework; path = Carthage/Build/PromisesObjC.xcframework; sourceTree = "<group>"; };
 		21989A0F27B6FF0D00539B7F /* TPPReaderSettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TPPReaderSettings.swift; sourceTree = "<group>"; };
 		2198F90F250A90EE000D9DAB /* AudioBookVendorsHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AudioBookVendorsHelper.swift; sourceTree = "<group>"; };
 		219901F324FD2DE9001BC727 /* jwk.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = jwk.json; sourceTree = "<group>"; };
@@ -1767,7 +1710,6 @@
 		21DCC3AD27BEDB5A00064B37 /* TPPReaderAppearance.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TPPReaderAppearance.swift; sourceTree = "<group>"; };
 		21DDE32725D2CEFC002CBCE3 /* AdobeDRMContentProtection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AdobeDRMContentProtection.swift; sourceTree = "<group>"; };
 		21DDE32D25D31DB4002CBCE3 /* AdobeDRMFetcher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AdobeDRMFetcher.swift; sourceTree = "<group>"; };
-		21DE2A8025B1FF5A00BCC9E0 /* R2Shared.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = R2Shared.framework; path = "../r2-lcp-swift/Carthage/Build/iOS/R2Shared.framework"; sourceTree = "<group>"; };
 		21DF7F9225AF5E1E0090402A /* ReaderModule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ReaderModule.swift; sourceTree = "<group>"; };
 		21DF7F9725AF5E560090402A /* ReaderFormatModule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ReaderFormatModule.swift; sourceTree = "<group>"; };
 		21E35FC2268CC8AC00066F9D /* AdobeContentProtectionService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AdobeContentProtectionService.swift; sourceTree = "<group>"; };
@@ -1778,7 +1720,6 @@
 		21F238C12499155E004DC0B1 /* AdobeDRMContainer.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = AdobeDRMContainer.mm; sourceTree = "<group>"; };
 		21F238C724991A2A004DC0B1 /* AdobeDRMLibraryService.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AdobeDRMLibraryService.swift; sourceTree = "<group>"; };
 		21F4BF3926BC62D4000CF592 /* AdobeCertificate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AdobeCertificate.swift; sourceTree = "<group>"; };
-		21F634E426D828CF00C8BE87 /* ReadiumLCP.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = ReadiumLCP.xcframework; path = Carthage/Build/ReadiumLCP.xcframework; sourceTree = "<group>"; };
 		21F7D3CA275A9D3C0080B44B /* String+HTMLEntities.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+HTMLEntities.swift"; sourceTree = "<group>"; };
 		260CAD4B2C1A0F7200BD54C6 /* Ekirjasto_Catalog_Feed_ellibs.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = Ekirjasto_Catalog_Feed_ellibs.json; sourceTree = "<group>"; };
 		260CAD4C2C1A0F7200BD54C6 /* Ekirjasto_Catalog_Feed_beta.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = Ekirjasto_Catalog_Feed_beta.json; sourceTree = "<group>"; };
@@ -1843,10 +1784,6 @@
 		5A569A261B8351C6003B5B61 /* ADEPT.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = ADEPT.xcodeproj; path = "adept-ios/ADEPT.xcodeproj"; sourceTree = "<group>"; };
 		5A5B90111B946763002C53E9 /* libc++.1.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = "libc++.1.dylib"; path = "usr/lib/libc++.1.dylib"; sourceTree = SDKROOT; };
 		5A5B90141B946CBD002C53E9 /* libstdc++.6.0.9.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = "libstdc++.6.0.9.dylib"; path = "usr/lib/libstdc++.6.0.9.dylib"; sourceTree = SDKROOT; };
-		5A69290D1B95ACC600FB4C10 /* readium-shared-js_all.js */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.javascript; name = "readium-shared-js_all.js"; path = "readium-shared-js/build-output/_single-bundle/readium-shared-js_all.js"; sourceTree = SOURCE_ROOT; };
-		5A69290F1B95ACD100FB4C10 /* sdk.css */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.css; name = sdk.css; path = "readium-shared-js/build-output/css/sdk.css"; sourceTree = SOURCE_ROOT; };
-		5A69291D1B95C8AD00FB4C10 /* readium-shared-js_all.js.map */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = "sourcecode.module-map"; name = "readium-shared-js_all.js.map"; path = "readium-shared-js/build-output/_single-bundle/readium-shared-js_all.js.map"; sourceTree = SOURCE_ROOT; };
-		5A6929231B95C8B400FB4C10 /* readium-shared-js_all.js.bundles.js */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.javascript; name = "readium-shared-js_all.js.bundles.js"; path = "readium-shared-js/build-output/_single-bundle/readium-shared-js_all.js.bundles.js"; sourceTree = SOURCE_ROOT; };
 		5D1B141422CBE3570006C964 /* TPPProblemDocument.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TPPProblemDocument.swift; sourceTree = "<group>"; };
 		5D1B142922CC179F0006C964 /* TPPAlertUtils.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TPPAlertUtils.swift; sourceTree = "<group>"; };
 		5D3A28CB22D3DA850042B3BD /* UserProfileDocument.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserProfileDocument.swift; sourceTree = "<group>"; };
@@ -1895,7 +1832,6 @@
 		731B2B12244A1D6500A7A649 /* R2Streamer.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = R2Streamer.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		731B2B18244A1D8600A7A649 /* R2Navigator.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = R2Navigator.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		732327B12478504500A041E6 /* NSError+NYPLAdditions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSError+NYPLAdditions.swift"; sourceTree = "<group>"; };
-		732752832578CB7900A073E2 /* R2LCPClient.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = R2LCPClient.framework; path = "../r2-lcp-swift/Carthage/Build/iOS/R2LCPClient.framework"; sourceTree = "<group>"; };
 		7327A89223EE017300954748 /* TPPMainThreadChecker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TPPMainThreadChecker.swift; sourceTree = "<group>"; };
 		732F474A260B224A00E2CB64 /* TPPBookmarkSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TPPBookmarkSpec.swift; sourceTree = "<group>"; };
 		732F929223ECB51F0099244C /* TPPBackgroundExecutor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TPPBackgroundExecutor.swift; sourceTree = "<group>"; };
@@ -1928,7 +1864,6 @@
 		7358A9532589A70B00E66D34 /* decode-install-secrets.sh */ = {isa = PBXFileReference; lastKnownFileType = text.script.sh; path = "decode-install-secrets.sh"; sourceTree = "<group>"; };
 		735DD0BD252299A90096D1F9 /* UIColor+NYPLAdditionsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIColor+NYPLAdditionsTests.swift"; sourceTree = "<group>"; };
 		735F41A2243E381D00046182 /* String+NYPLAdditionsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+NYPLAdditionsTests.swift"; sourceTree = "<group>"; };
-		735FC2D42485C178009CF11E /* SwiftSoup.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SwiftSoup.framework; path = "../r2-navigator-swift/Carthage/Build/iOS/SwiftSoup.framework"; sourceTree = "<group>"; };
 		735FED252427494900144C97 /* TPPNetworkResponder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TPPNetworkResponder.swift; sourceTree = "<group>"; };
 		73609AD8245B53CB00F0E08B /* update-certificates.sh */ = {isa = PBXFileReference; lastKnownFileType = text.script.sh; name = "update-certificates.sh"; path = "scripts/update-certificates.sh"; sourceTree = SOURCE_ROOT; };
 		7360D0D424BFCB9700C8AD16 /* TPPUserFriendlyError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TPPUserFriendlyError.swift; sourceTree = "<group>"; };
@@ -1942,7 +1877,6 @@
 		7384C7FF242BB43300D5F960 /* TPPCachingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TPPCachingTests.swift; sourceTree = "<group>"; };
 		7384C801242BCC4800D5F960 /* Date+NYPLAdditions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Date+NYPLAdditions.swift"; sourceTree = "<group>"; };
 		7384C803242BCE5900D5F960 /* Date+NYPLAdditionsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Date+NYPLAdditionsTests.swift"; sourceTree = "<group>"; };
-		738574AD25A631AF001E615D /* Minizip.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Minizip.framework; path = Carthage/Build/iOS/Minizip.framework; sourceTree = "<group>"; };
 		7386C1F3245225A5004C78BD /* TPPReaderPositionsVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TPPReaderPositionsVC.swift; sourceTree = "<group>"; };
 		7386C1F624525AFF004C78BD /* TPPReaderTOCBusinessLogic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TPPReaderTOCBusinessLogic.swift; sourceTree = "<group>"; };
 		7386C1F9245276CA004C78BD /* TPPReaderTOCCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TPPReaderTOCCell.swift; sourceTree = "<group>"; };
@@ -1950,16 +1884,6 @@
 		738E4715258ABB6300BEEC1D /* build-carthage-R2-integration.sh */ = {isa = PBXFileReference; lastKnownFileType = text.script.sh; path = "build-carthage-R2-integration.sh"; sourceTree = "<group>"; };
 		738EF2CB2405E38800F388FB /* GoogleService-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; name = "GoogleService-Info.plist"; path = "PalaceConfig/GoogleService-Info.plist"; sourceTree = SOURCE_ROOT; };
 		738EF2D12405E3D900F388FB /* .gitignore */ = {isa = PBXFileReference; lastKnownFileType = text; path = .gitignore; sourceTree = SOURCE_ROOT; };
-		738EF2D32405EA5F00F388FB /* FirebaseCoreDiagnostics.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = FirebaseCoreDiagnostics.framework; path = Carthage/Build/iOS/FirebaseCoreDiagnostics.framework; sourceTree = "<group>"; };
-		738EF2D42405EA5F00F388FB /* FirebaseCore.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = FirebaseCore.framework; path = Carthage/Build/iOS/FirebaseCore.framework; sourceTree = "<group>"; };
-		738EF2D52405EA5F00F388FB /* FirebaseAnalytics.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = FirebaseAnalytics.framework; path = Carthage/Build/iOS/FirebaseAnalytics.framework; sourceTree = "<group>"; };
-		738EF2D72405EA6000F388FB /* nanopb.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = nanopb.framework; path = Carthage/Build/iOS/nanopb.framework; sourceTree = "<group>"; };
-		738EF2D82405EA6000F388FB /* GoogleUtilities.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = GoogleUtilities.framework; path = Carthage/Build/iOS/GoogleUtilities.framework; sourceTree = "<group>"; };
-		738EF2D92405EA6000F388FB /* GoogleAppMeasurement.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = GoogleAppMeasurement.framework; path = Carthage/Build/iOS/GoogleAppMeasurement.framework; sourceTree = "<group>"; };
-		738EF2DA2405EA6000F388FB /* FIRAnalyticsConnector.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = FIRAnalyticsConnector.framework; path = Carthage/Build/iOS/FIRAnalyticsConnector.framework; sourceTree = "<group>"; };
-		738EF2E42405EBAD00F388FB /* FirebaseInstallations.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = FirebaseInstallations.framework; path = Carthage/Build/iOS/FirebaseInstallations.framework; sourceTree = "<group>"; };
-		738EF2E52405EBAD00F388FB /* GoogleDataTransport.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = GoogleDataTransport.framework; path = Carthage/Build/iOS/GoogleDataTransport.framework; sourceTree = "<group>"; };
-		738EF2EB2405EC5900F388FB /* PromisesObjC.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = PromisesObjC.framework; path = Carthage/Build/iOS/PromisesObjC.framework; sourceTree = "<group>"; };
 		739062D125358CF900D0743D /* TPPSignInBusinessLogicUIDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TPPSignInBusinessLogicUIDelegate.swift; sourceTree = "<group>"; };
 		739E6157244A0F6D00D00301 /* R2Shared.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = R2Shared.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		739ECB2325101CCE00691A70 /* NSNotification+TPP.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSNotification+TPP.swift"; sourceTree = "<group>"; };
@@ -1974,7 +1898,6 @@
 		73A794BC2548E36100C59CC1 /* TPPBookCreationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TPPBookCreationTests.swift; sourceTree = "<group>"; };
 		73A794C62549095700C59CC1 /* NYPLOPDSAcquisitionPathEntryMinimal.xml */ = {isa = PBXFileReference; lastKnownFileType = text.xml; path = NYPLOPDSAcquisitionPathEntryMinimal.xml; sourceTree = "<group>"; };
 		73A794C925492C9800C59CC1 /* TPPFake.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TPPFake.swift; sourceTree = "<group>"; };
-		73A7BA4D25A62FE900C2906C /* R2LCPClient.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = R2LCPClient.framework; path = Carthage/Build/iOS/R2LCPClient.framework; sourceTree = "<group>"; };
 		73B501C024F48D4B00FBAD7D /* TPPUserAccountFrontEndValidation.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TPPUserAccountFrontEndValidation.swift; sourceTree = "<group>"; };
 		73B5DFDA26052A1800225C12 /* TPPBookButtonsState.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = TPPBookButtonsState.m; sourceTree = "<group>"; };
 		73B5DFDB26052A1800225C12 /* TPPBookButtonsState.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TPPBookButtonsState.h; sourceTree = "<group>"; };
@@ -1982,7 +1905,6 @@
 		73C3CF5925CB8D6100CA8166 /* NYPLNetworkExecutorMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NYPLNetworkExecutorMock.swift; sourceTree = "<group>"; };
 		73CC48A4260BFC4800F1E2C3 /* TPPReadiumBookmark+R2.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "TPPReadiumBookmark+R2.swift"; sourceTree = "<group>"; };
 		73CDA120243EDAD8009CC6A6 /* URLRequest+Logging.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "URLRequest+Logging.swift"; sourceTree = "<group>"; };
-		73CEF82F252699C9006B2820 /* FirebaseCrashlytics.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = FirebaseCrashlytics.framework; path = Carthage/Build/iOS/FirebaseCrashlytics.framework; sourceTree = "<group>"; };
 		73CEF8352526FE80006B2820 /* run */ = {isa = PBXFileReference; lastKnownFileType = text.script.sh; path = run; sourceTree = "<group>"; };
 		73CEF8362526FE80006B2820 /* upload-symbols */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.executable"; path = "upload-symbols"; sourceTree = "<group>"; };
 		73CEF83E25270F38006B2820 /* adobe-rmsdk-build.sh */ = {isa = PBXFileReference; lastKnownFileType = text.script.sh; name = "adobe-rmsdk-build.sh"; path = "scripts/adobe-rmsdk-build.sh"; sourceTree = SOURCE_ROOT; };
@@ -1995,9 +1917,6 @@
 		73DB56CB25F7F684003788EE /* TPPLastReadPositionPoster.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TPPLastReadPositionPoster.swift; sourceTree = "<group>"; };
 		73DE8979260BEA13003D9135 /* TPPRequestExecuting.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TPPRequestExecuting.swift; sourceTree = "<group>"; };
 		73DEB5462486FDFC00B5FF0A /* TPPBookmarkR2Location.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TPPBookmarkR2Location.swift; sourceTree = "<group>"; };
-		73DED81D25A630DB00A4D63B /* CryptoSwift.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CryptoSwift.framework; path = Carthage/Build/iOS/CryptoSwift.framework; sourceTree = "<group>"; };
-		73DED82125A630FF00A4D63B /* Fuzi.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Fuzi.framework; path = Carthage/Build/iOS/Fuzi.framework; sourceTree = "<group>"; };
-		73DED82525A6311A00A4D63B /* GCDWebServer.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = GCDWebServer.framework; path = Carthage/Build/iOS/GCDWebServer.framework; sourceTree = "<group>"; };
 		73EB0B7525821DF4006BC997 /* Palace-noDRM.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "Palace-noDRM.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		73EB0B7F2582CCE9006BC997 /* build-3rd-party-dependencies.sh */ = {isa = PBXFileReference; lastKnownFileType = text.script.sh; path = "build-3rd-party-dependencies.sh"; sourceTree = "<group>"; };
 		73EB0B802582CD59006BC997 /* bootstrap-drm.sh */ = {isa = PBXFileReference; lastKnownFileType = text.script.sh; path = "bootstrap-drm.sh"; sourceTree = "<group>"; };
@@ -2069,7 +1988,6 @@
 		A46226261B39D4980063F549 /* TPPOPDSGroup.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TPPOPDSGroup.h; sourceTree = "<group>"; };
 		A499BF241B39EFC7002F8B8B /* TPPOPDSEntryGroupAttributes.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TPPOPDSEntryGroupAttributes.h; sourceTree = "<group>"; };
 		A499BF251B39EFC7002F8B8B /* TPPOPDSEntryGroupAttributes.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = TPPOPDSEntryGroupAttributes.m; sourceTree = "<group>"; };
-		A49C25401AE05A2600D63B89 /* RDServices.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; path = RDServices.xcodeproj; sourceTree = "<group>"; };
 		A4BA1D0C1B430341006F83DF /* TPPCatalogGroupedFeedViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TPPCatalogGroupedFeedViewController.h; sourceTree = "<group>"; };
 		A4BA1D0D1B430341006F83DF /* TPPCatalogGroupedFeedViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = TPPCatalogGroupedFeedViewController.m; sourceTree = "<group>"; };
 		A4BA1D111B43046B006F83DF /* TPPCatalogGroupedFeed.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TPPCatalogGroupedFeed.h; sourceTree = "<group>"; };
@@ -2085,7 +2003,6 @@
 		A823D833192BABA400B55DE2 /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/InfoPlist.strings; sourceTree = "<group>"; };
 		A92FB0F821CDCE3D004740F4 /* TPPReturnPromptHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TPPReturnPromptHelper.swift; sourceTree = "<group>"; };
 		A93F9F9621CDACF700BD3B0C /* TPPAppReviewPrompt.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TPPAppReviewPrompt.swift; sourceTree = "<group>"; };
-		A9AD993F2225D4AF009FF54A /* PDFRendererProvider.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = PDFRendererProvider.framework; path = Carthage/Build/iOS/PDFRendererProvider.framework; sourceTree = "<group>"; };
 		AE77E0F3FB181D0C1529C865 /* TPPOPDSLink.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TPPOPDSLink.h; sourceTree = "<group>"; };
 		AE77E304AA30ABF2921B6393 /* TPPOPDSFeed.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TPPOPDSFeed.h; sourceTree = "<group>"; };
 		AE77E4AF64208439F78B3D73 /* TPPOPDSEntry.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = TPPOPDSEntry.m; sourceTree = "<group>"; };
@@ -2155,7 +2072,6 @@
 		E5824BDE2994AC2900DE76C2 /* NormalBookCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NormalBookCell.swift; sourceTree = "<group>"; };
 		E5824BE02994AF4800DE76C2 /* DownloadingBookCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DownloadingBookCell.swift; sourceTree = "<group>"; };
 		E5824BE22994B29700DE76C2 /* ButtonView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ButtonView.swift; sourceTree = "<group>"; };
-		E58565CE269774C400A5FBD5 /* AudioEngine.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = AudioEngine.xcframework; path = Carthage/Build/AudioEngine.xcframework; sourceTree = "<group>"; };
 		E58565D2269774D900A5FBD5 /* NYPLAEToolkit.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; path = NYPLAEToolkit.xcframework; sourceTree = "<group>"; };
 		E585662026979AC100A5FBD5 /* NYPLAEToolkit.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = NYPLAEToolkit.xcodeproj; path = "ios-drm-audioengine/NYPLAEToolkit.xcodeproj"; sourceTree = "<group>"; };
 		E59526EA28D24FC000C179DA /* AudiobookSample.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AudiobookSample.swift; sourceTree = "<group>"; };
@@ -2218,7 +2134,6 @@
 		E706F6082863831F000B7431 /* TPPPDFPage+serialization.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "TPPPDFPage+serialization.swift"; sourceTree = "<group>"; };
 		E706F60A2863864F000B7431 /* CGPDFPage+previews.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CGPDFPage+previews.swift"; sourceTree = "<group>"; };
 		E706F60E286388B3000B7431 /* TPPPDFDocumentMetadata.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TPPPDFDocumentMetadata.swift; sourceTree = "<group>"; };
-		E708C18C27734EE300D34899 /* DifferenceKit.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = DifferenceKit.xcframework; path = Carthage/Build/DifferenceKit.xcframework; sourceTree = "<group>"; };
 		E708F712284780920028405B /* TPPEncryptedPDFPageViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TPPEncryptedPDFPageViewController.swift; sourceTree = "<group>"; };
 		E708F71F284781D50028405B /* TPPEncryptedPDFViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TPPEncryptedPDFViewController.swift; sourceTree = "<group>"; };
 		E708F722284783250028405B /* TPPEncryptedPDFViewer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TPPEncryptedPDFViewer.swift; sourceTree = "<group>"; };
@@ -2263,7 +2178,6 @@
 		E7B20B38285B3AC400C49FE1 /* TPPPDFPreviewGrid.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TPPPDFPreviewGrid.swift; sourceTree = "<group>"; };
 		E7B20B45285B3BC800C49FE1 /* TPPPDFPreviewGridController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TPPPDFPreviewGridController.swift; sourceTree = "<group>"; };
 		E7B20B48285B4E5600C49FE1 /* TPPPDFLabel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TPPPDFLabel.swift; sourceTree = "<group>"; };
-		E7BF790C296F5F7600137D9F /* FirebaseMessaging.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = FirebaseMessaging.xcframework; path = Carthage/Build/FirebaseMessaging.xcframework; sourceTree = "<group>"; };
 		E7C0F2F0299586E8003A10C5 /* Strings+objC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Strings+objC.swift"; sourceTree = "<group>"; };
 		E7C4BD6029BA70710079F729 /* TPPTextToSpeech.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TPPTextToSpeech.swift; sourceTree = "<group>"; };
 		E7CBF976285CA41400F00C02 /* TPPPDFDocument.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TPPPDFDocument.swift; sourceTree = "<group>"; };
@@ -2304,7 +2218,6 @@
 				33E326612AC4674B00C6B6BD /* ULID in Frameworks */,
 				331264282A287F53006BA87D /* CoreGraphics.framework in Frameworks */,
 				331264292A287F53006BA87D /* QuartzCore.framework in Frameworks */,
-				3312642B2A287F53006BA87D /* libRDServices.a in Frameworks */,
 				33372CF72AC548EA0001BE2F /* FirebaseAnalytics in Frameworks */,
 				3312642C2A287F53006BA87D /* R2Navigator in Frameworks */,
 				363C61F42B14E5B800858AA5 /* ReadiumLCP in Frameworks */,
@@ -2347,7 +2260,6 @@
 				73EB0B3325821DF4006BC997 /* libiconv.tbd in Frameworks */,
 				73EB0B3425821DF4006BC997 /* CoreGraphics.framework in Frameworks */,
 				73EB0B3525821DF4006BC997 /* QuartzCore.framework in Frameworks */,
-				73EB0B3825821DF4006BC997 /* libRDServices.a in Frameworks */,
 				E77D02272931360100544180 /* R2Navigator in Frameworks */,
 				73EB0B3925821DF4006BC997 /* libicucore.tbd in Frameworks */,
 				E7498A8E2A0E7F840037DD93 /* FirebaseAnalytics in Frameworks */,
@@ -2388,7 +2300,6 @@
 				A823D813192BABA400B55DE2 /* CoreGraphics.framework in Frameworks */,
 				03B092241E78839D00AD338D /* QuartzCore.framework in Frameworks */,
 				08C469C11BDAAEB1009D8AFD /* libADEPT.a in Frameworks */,
-				08A352271BDE91B80040BF1D /* libRDServices.a in Frameworks */,
 				08A352221BDE8E560040BF1D /* libicucore.tbd in Frameworks */,
 				5AEA9E011B947419009F71DB /* libc++.dylib in Frameworks */,
 				2DA4F2331C68363B008853D7 /* LocalAuthentication.framework in Frameworks */,
@@ -2445,10 +2356,6 @@
 				11C113D119F842BE005B3F63 /* host_app_feedback.js */,
 				11C113CF19F842B9005B3F63 /* reader.html */,
 				11C113D519F84613005B3F63 /* simplified.js */,
-				5A69290F1B95ACD100FB4C10 /* sdk.css */,
-				5A6929231B95C8B400FB4C10 /* readium-shared-js_all.js.bundles.js */,
-				5A69291D1B95C8AD00FB4C10 /* readium-shared-js_all.js.map */,
-				5A69290D1B95ACC600FB4C10 /* readium-shared-js_all.js */,
 			);
 			name = Reader;
 			sourceTree = "<group>";
@@ -3633,7 +3540,6 @@
 		A49C25411AE05A2600D63B89 /* Products */ = {
 			isa = PBXGroup;
 			children = (
-				A49C25461AE05A2600D63B89 /* libRDServices.a */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -3646,7 +3552,6 @@
 				E5C1F52927990929005FC6B2 /* OverdriveProcessor.xcodeproj */,
 				E585662026979AC100A5FBD5 /* NYPLAEToolkit.xcodeproj */,
 				5A569A261B8351C6003B5B61 /* ADEPT.xcodeproj */,
-				A49C25401AE05A2600D63B89 /* RDServices.xcodeproj */,
 				1112A8191A322C53002B8CC1 /* TenPrintCover.xcodeproj */,
 				A823D816192BABA400B55DE2 /* Palace */,
 				A823D82F192BABA400B55DE2 /* PalaceTests */,
@@ -3672,71 +3577,15 @@
 			isa = PBXGroup;
 			children = (
 				368576E52BCE7E8D009AA032 /* CloudKit.framework */,
-				E7BF790C296F5F7600137D9F /* FirebaseMessaging.xcframework */,
 				E7F287782956566800EEB1E0 /* R2LCPClient.xcframework */,
-				E708C18C27734EE300D34899 /* DifferenceKit.xcframework */,
-				21F634E426D828CF00C8BE87 /* ReadiumLCP.xcframework */,
 				E58565D2269774D900A5FBD5 /* NYPLAEToolkit.xcframework */,
-				E58565CE269774C400A5FBD5 /* AudioEngine.xcframework */,
-				219869CE267E80800041369E /* GoogleAppMeasurement.xcframework */,
-				219869CD267E80800041369E /* GoogleDataTransport.xcframework */,
-				219869D0267E80800041369E /* GoogleUtilities.xcframework */,
-				219869CF267E80800041369E /* nanopb.xcframework */,
-				219869D1267E80800041369E /* PromisesObjC.xcframework */,
-				21986999267E78FC0041369E /* FirebaseAnalytics.xcframework */,
-				2198699B267E78FC0041369E /* FirebaseCore.xcframework */,
-				2198699C267E78FD0041369E /* FirebaseCoreDiagnostics.xcframework */,
-				21986998267E78FC0041369E /* FirebaseCrashlytics.xcframework */,
-				2198699A267E78FC0041369E /* FirebaseInstallations.xcframework */,
-				2198694C267E2A140041369E /* ZXingObjC.xcframework */,
-				21986947267E2A120041369E /* ZIPFoundation.xcframework */,
-				21986940267E2A0A0041369E /* SwiftSoup.xcframework */,
-				21986939267E2A030041369E /* SQLite.xcframework */,
-				21986932267E29F30041369E /* R2Streamer.xcframework */,
-				2198692D267E29EE0041369E /* R2Shared.xcframework */,
-				21986928267E29EA0041369E /* R2Navigator.xcframework */,
 				21986921267E29D70041369E /* PureLayout.xcframework */,
-				2198691A267E29CC0041369E /* PDFRendererProvider.xcframework */,
-				21986913267E29BC0041369E /* NYPLAudiobookToolkit.xcframework */,
 				2198690C267E29B00041369E /* Minizip.xcframework */,
-				21986905267E299E0041369E /* GCDWebServer.xcframework */,
-				219868FE267E29920041369E /* Fuzi.xcframework */,
-				219868F6267E29830041369E /* CryptoSwift.xcframework */,
-				2156B54625B200F6003AD8EC /* ReadiumLCP.framework */,
-				2156B54425B200EA003AD8EC /* R2LCPClient.framework */,
 				73F36BD325CC76C60057954C /* XCTest.framework */,
-				170E5FBD25AFDD64007D6DE6 /* ZIPFoundation.framework */,
-				73A7BA4D25A62FE900C2906C /* R2LCPClient.framework */,
-				21DE2A8025B1FF5A00BCC9E0 /* R2Shared.framework */,
-				732752832578CB7900A073E2 /* R2LCPClient.framework */,
-				735FC2D42485C178009CF11E /* SwiftSoup.framework */,
-				73DED81D25A630DB00A4D63B /* CryptoSwift.framework */,
-				73DED82125A630FF00A4D63B /* Fuzi.framework */,
-				73DED82525A6311A00A4D63B /* GCDWebServer.framework */,
-				738574AD25A631AF001E615D /* Minizip.framework */,
 				731B2B18244A1D8600A7A649 /* R2Navigator.framework */,
 				731B2B12244A1D6500A7A649 /* R2Streamer.framework */,
 				739E6157244A0F6D00D00301 /* R2Shared.framework */,
-				73CEF82F252699C9006B2820 /* FirebaseCrashlytics.framework */,
 				7347F132245A508400558D7F /* NYPLCardCreator.framework */,
-				17D08378248E8EEB00092AA9 /* OverdriveProcessor.framework */,
-				738EF2EB2405EC5900F388FB /* PromisesObjC.framework */,
-				738EF2E42405EBAD00F388FB /* FirebaseInstallations.framework */,
-				738EF2E52405EBAD00F388FB /* GoogleDataTransport.framework */,
-				738EF2DA2405EA6000F388FB /* FIRAnalyticsConnector.framework */,
-				738EF2D52405EA5F00F388FB /* FirebaseAnalytics.framework */,
-				738EF2D42405EA5F00F388FB /* FirebaseCore.framework */,
-				738EF2D32405EA5F00F388FB /* FirebaseCoreDiagnostics.framework */,
-				738EF2D92405EA6000F388FB /* GoogleAppMeasurement.framework */,
-				738EF2D82405EA6000F388FB /* GoogleUtilities.framework */,
-				738EF2D72405EA6000F388FB /* nanopb.framework */,
-				A9AD993F2225D4AF009FF54A /* PDFRendererProvider.framework */,
-				148B1C1721710C6800FF64AB /* NYPLAEToolkit.framework */,
-				148B1C1C21710C6800FF64AB /* NYPLAudiobookToolkit.framework */,
-				145DA49521544A420055DB93 /* PureLayout.framework */,
-				145DA49321544A3F0055DB93 /* NYPLCardCreator.framework */,
-				145DA4912154464F0055DB93 /* SQLite.framework */,
-				145DA48D215441A70055DB93 /* ZXingObjC.framework */,
 				03B0922F1E78871A00AD338D /* MediaPlayer.framework */,
 				03B0922D1E7886ED00AD338D /* CoreVideo.framework */,
 				03B0922B1E7886C900AD338D /* AVFoundation.framework */,
@@ -3759,7 +3608,6 @@
 				119503EA1993F91E009FB788 /* libc++.dylib */,
 				119503E81993F919009FB788 /* libz.dylib */,
 				119503E61993F914009FB788 /* libxml2.dylib */,
-				119503E41993F90C009FB788 /* libePub3-iOS.a */,
 				A823D810192BABA400B55DE2 /* Foundation.framework */,
 				A823D812192BABA400B55DE2 /* CoreGraphics.framework */,
 				A823D814192BABA400B55DE2 /* UIKit.framework */,
@@ -4380,7 +4228,6 @@
 				},
 				{
 					ProductGroup = A49C25411AE05A2600D63B89 /* Products */;
-					ProjectRef = A49C25401AE05A2600D63B89 /* RDServices.xcodeproj */;
 				},
 				{
 					ProductGroup = 1112A81A1A322C53002B8CC1 /* Products */;
@@ -4417,13 +4264,6 @@
 			fileType = archive.ar;
 			path = libADEPT.a;
 			remoteRef = 5A569A2B1B8351C6003B5B61 /* PBXContainerItemProxy */;
-			sourceTree = BUILT_PRODUCTS_DIR;
-		};
-		A49C25461AE05A2600D63B89 /* libRDServices.a */ = {
-			isa = PBXReferenceProxy;
-			fileType = archive.ar;
-			path = libRDServices.a;
-			remoteRef = A49C25451AE05A2600D63B89 /* PBXContainerItemProxy */;
 			sourceTree = BUILT_PRODUCTS_DIR;
 		};
 		E585662526979AC100A5FBD5 /* NYPLAEToolkit.framework */ = {
@@ -4518,7 +4358,6 @@
 				331264482A287F53006BA87D /* simplified.js in Resources */,
 				331264492A287F53006BA87D /* TPPProblemReportViewController.xib in Resources */,
 				3312644A2A287F53006BA87D /* OpenSans-Regular.ttf in Resources */,
-				3312644C2A287F53006BA87D /* readium-shared-js_all.js in Resources */,
 				368EE7682BC5F82200663D37 /* PrivacyInfo.xcprivacy in Resources */,
 				3312644D2A287F53006BA87D /* ReaderClientCert.sig in Resources */,
 				3312644E2A287F53006BA87D /* Localizable.stringsdict in Resources */,
@@ -4534,19 +4373,16 @@
 				331264552A287F53006BA87D /* DetailSummaryTemplate.html in Resources */,
 				33266F032A40459E003BC347 /* Colors.xcassets in Resources */,
 				3360FBA72A41B2E100AC1905 /* Ekirjasto_Launch_Screen.storyboard in Resources */,
-				331264592A287F53006BA87D /* sdk.css in Resources */,
 				3372514A2A9F4ED30072DA02 /* Asap-Bold.ttf in Resources */,
 				3312645A2A287F53006BA87D /* OpenSans-SemiBold.ttf in Resources */,
 				3312645B2A287F53006BA87D /* OpenDyslexic3-Bold.ttf in Resources */,
 				260CAD502C1A0F7200BD54C6 /* Ekirjasto_Catalog_Feed_dev.json in Resources */,
-				3312645C2A287F53006BA87D /* readium-shared-js_all.js.map in Resources */,
 				3312645E2A287F53006BA87D /* TPPReaderPositions.storyboard in Resources */,
 				3312645F2A287F53006BA87D /* host_app_feedback.js in Resources */,
 				33372CFC2AC54B8A0001BE2F /* GoogleService-Info.plist in Resources */,
 				33266EFB2A4037B6003BC347 /* Asap-Regular.ttf in Resources */,
 				309262C42BFD57EB003CCA2F /* Ekirjasto_Catalog_Feed_production.json in Resources */,
 				331264612A287F53006BA87D /* txstrings.json in Resources */,
-				331264622A287F53006BA87D /* readium-shared-js_all.js.bundles.js in Resources */,
 				331264632A287F53006BA87D /* OpenDyslexic3-Regular.ttf in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -4559,7 +4395,6 @@
 				73EB0B5A25821DF4006BC997 /* simplified.js in Resources */,
 				73EB0B5B25821DF4006BC997 /* TPPProblemReportViewController.xib in Resources */,
 				E5BEF00926BD919F00C2A50B /* OpenSans-Regular.ttf in Resources */,
-				73EB0B5C25821DF4006BC997 /* readium-shared-js_all.js in Resources */,
 				73EB0B5D25821DF4006BC997 /* ReaderClientCert.sig in Resources */,
 				17E81F2F261FF758001003C2 /* Localizable.stringsdict in Resources */,
 				73EB0B5E25821DF4006BC997 /* software-licenses.html in Resources */,
@@ -4570,15 +4405,12 @@
 				73EB0B6325821DF4006BC997 /* DetailSummaryTemplate.html in Resources */,
 				216FD1FC26DFE112003AF0D8 /* Colors.xcassets in Resources */,
 				73EB0B6525821DF4006BC997 /* Images.xcassets in Resources */,
-				73EB0B6625821DF4006BC997 /* sdk.css in Resources */,
 				E5BEF02A26BDAB3A00C2A50B /* OpenSans-SemiBold.ttf in Resources */,
 				73EB0B6725821DF4006BC997 /* OpenDyslexic3-Bold.ttf in Resources */,
-				73EB0B6925821DF4006BC997 /* readium-shared-js_all.js.map in Resources */,
 				3360FBA82A41B2E500AC1905 /* TPP_Launch_Screen.storyboard in Resources */,
 				73D8D27A25A68D3B00DF5F69 /* TPPReaderPositions.storyboard in Resources */,
 				73EB0B6A25821DF4006BC997 /* host_app_feedback.js in Resources */,
 				E5D3288B292C0D68008BFD01 /* txstrings.json in Resources */,
-				73EB0B6B25821DF4006BC997 /* readium-shared-js_all.js.bundles.js in Resources */,
 				73EB0B6C25821DF4006BC997 /* OpenDyslexic3-Regular.ttf in Resources */,
 				73EB0B6D25821DF4006BC997 /* GoogleService-Info.plist in Resources */,
 				36A527EA2BDBD399009101F5 /* TestLogin_Catalog_Feed.json in Resources */,
@@ -4593,7 +4425,6 @@
 				11C113D719F84613005B3F63 /* simplified.js in Resources */,
 				085D31D91BE29ED4007F7672 /* TPPProblemReportViewController.xib in Resources */,
 				E5BEF00826BD919F00C2A50B /* OpenSans-Regular.ttf in Resources */,
-				5A69290E1B95ACC600FB4C10 /* readium-shared-js_all.js in Resources */,
 				2D4379FE1C46FDB600AE1AD5 /* ReaderClientCert.sig in Resources */,
 				17E81F2C261FF758001003C2 /* Localizable.stringsdict in Resources */,
 				2D6256911D41582A0080A81F /* software-licenses.html in Resources */,
@@ -4605,14 +4436,11 @@
 				110F853E19D5FA7300052DF7 /* DetailSummaryTemplate.html in Resources */,
 				E5506DE426C4688D009FA623 /* Colors.xcassets in Resources */,
 				A823D823192BABA400B55DE2 /* Images.xcassets in Resources */,
-				5A6929101B95ACD100FB4C10 /* sdk.css in Resources */,
 				E5BEF02826BDAB3A00C2A50B /* OpenSans-SemiBold.ttf in Resources */,
 				84B7A3471B84E8FE00584FB2 /* OpenDyslexic3-Bold.ttf in Resources */,
-				5A6929251B95C93B00FB4C10 /* readium-shared-js_all.js.map in Resources */,
 				7347F0272459E10900558D7F /* TPPReaderPositions.storyboard in Resources */,
 				11C113D219F842BE005B3F63 /* host_app_feedback.js in Resources */,
 				E5D3288A292C0D34008BFD01 /* txstrings.json in Resources */,
-				5A6929241B95C8B400FB4C10 /* readium-shared-js_all.js.bundles.js in Resources */,
 				84B7A3481B84E8FE00584FB2 /* OpenDyslexic3-Regular.ttf in Resources */,
 				738EF2D02405E38800F388FB /* GoogleService-Info.plist in Resources */,
 				36A527E92BDBD399009101F5 /* TestLogin_Catalog_Feed.json in Resources */,
@@ -6110,7 +5938,7 @@
 				CODE_SIGN_IDENTITY = "Apple Development";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 10000;
+				CURRENT_PROJECT_VERSION = "10000";
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = QA5XMCRV5M;
 				ENABLE_BITCODE = NO;
@@ -6174,7 +6002,7 @@
 				CODE_SIGN_IDENTITY = "Apple Development";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "Apple Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 10000;
+				CURRENT_PROJECT_VERSION = "10000";
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = 88CBA74T8K;
 				ENABLE_BITCODE = NO;
@@ -6234,7 +6062,7 @@
 				CODE_SIGN_ENTITLEMENTS = Palace/PalaceDebug.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 10000;
+				CURRENT_PROJECT_VERSION = "10000";
 				DEVELOPMENT_TEAM = "";
 				ENABLE_BITCODE = NO;
 				FRAMEWORK_SEARCH_PATHS = (
@@ -6308,8 +6136,6 @@
 				HEADER_SEARCH_PATHS = (
 					"$(inherited)",
 					"\"$(SDKROOT)/usr/include/libxml2\"",
-					"\"$(SRCROOT)/readium-sdk/Platform/Apple/RDServices\"",
-					"\"$(SRCROOT)/readium-sdk/Platform/Apple/include\"",
 					"\"$(SRCROOT)/ios-tenprintcover/TenPrintCover\"",
 					"\"$(SRCROOT)/ios-audiobook-overdrive/OverdriveProcessor\"",
 					"\"$(SRCROOT)/adept-ios\"",
@@ -6424,7 +6250,7 @@
 				CODE_SIGN_IDENTITY = "Apple Development";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 10000;
+				CURRENT_PROJECT_VERSION = "10000";
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = QA5XMCRV5M;
 				ENABLE_BITCODE = NO;
@@ -6488,7 +6314,7 @@
 				CODE_SIGN_IDENTITY = "Apple Development";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "Apple Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 10000;
+				CURRENT_PROJECT_VERSION = "10000";
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = 88CBA74T8K;
 				ENABLE_BITCODE = NO;
@@ -6548,7 +6374,7 @@
 				CODE_SIGN_ENTITLEMENTS = Palace/PalaceDebug.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 10000;
+				CURRENT_PROJECT_VERSION = "10000";
 				DEVELOPMENT_TEAM = "";
 				ENABLE_BITCODE = NO;
 				FRAMEWORK_SEARCH_PATHS = (
@@ -6622,8 +6448,6 @@
 				HEADER_SEARCH_PATHS = (
 					"$(inherited)",
 					"\"$(SDKROOT)/usr/include/libxml2\"",
-					"\"$(SRCROOT)/readium-sdk/Platform/Apple/RDServices\"",
-					"\"$(SRCROOT)/readium-sdk/Platform/Apple/include\"",
 					"\"$(SRCROOT)/ios-tenprintcover/TenPrintCover\"",
 					"\"$(SRCROOT)/ios-audiobook-overdrive/OverdriveProcessor\"",
 					"\"$(SRCROOT)/adept-ios\"",
@@ -6738,7 +6562,7 @@
 				CODE_SIGN_IDENTITY = "Apple Development";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 10000;
+				CURRENT_PROJECT_VERSION = "10000";
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = QA5XMCRV5M;
 				ENABLE_BITCODE = NO;
@@ -6802,7 +6626,7 @@
 				CODE_SIGN_IDENTITY = "Apple Development";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "Apple Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 10000;
+				CURRENT_PROJECT_VERSION = "10000";
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = 88CBA74T8K;
 				ENABLE_BITCODE = NO;
@@ -6862,7 +6686,7 @@
 				CODE_SIGN_ENTITLEMENTS = Palace/PalaceDebug.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 10000;
+				CURRENT_PROJECT_VERSION = "10000";
 				DEVELOPMENT_TEAM = "";
 				ENABLE_BITCODE = NO;
 				FRAMEWORK_SEARCH_PATHS = (
@@ -6936,8 +6760,6 @@
 				HEADER_SEARCH_PATHS = (
 					"$(inherited)",
 					"\"$(SDKROOT)/usr/include/libxml2\"",
-					"\"$(SRCROOT)/readium-sdk/Platform/Apple/RDServices\"",
-					"\"$(SRCROOT)/readium-sdk/Platform/Apple/include\"",
 					"\"$(SRCROOT)/ios-tenprintcover/TenPrintCover\"",
 					"\"$(SRCROOT)/ios-audiobook-overdrive/OverdriveProcessor\"",
 					"\"$(SRCROOT)/adept-ios\"",
@@ -7052,7 +6874,7 @@
 				CODE_SIGN_IDENTITY = "Apple Development";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 10000;
+				CURRENT_PROJECT_VERSION = "10000";
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = QA5XMCRV5M;
 				ENABLE_BITCODE = NO;
@@ -7116,7 +6938,7 @@
 				CODE_SIGN_IDENTITY = "Apple Development";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "Apple Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 10000;
+				CURRENT_PROJECT_VERSION = "10000";
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = 88CBA74T8K;
 				ENABLE_BITCODE = NO;
@@ -7176,7 +6998,7 @@
 				CODE_SIGN_ENTITLEMENTS = Palace/PalaceDebug.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 10000;
+				CURRENT_PROJECT_VERSION = "10000";
 				DEVELOPMENT_TEAM = "";
 				ENABLE_BITCODE = NO;
 				FRAMEWORK_SEARCH_PATHS = (
@@ -7250,8 +7072,6 @@
 				HEADER_SEARCH_PATHS = (
 					"$(inherited)",
 					"\"$(SDKROOT)/usr/include/libxml2\"",
-					"\"$(SRCROOT)/readium-sdk/Platform/Apple/RDServices\"",
-					"\"$(SRCROOT)/readium-sdk/Platform/Apple/include\"",
 					"\"$(SRCROOT)/ios-tenprintcover/TenPrintCover\"",
 					"\"$(SRCROOT)/ios-audiobook-overdrive/OverdriveProcessor\"",
 					"\"$(SRCROOT)/adept-ios\"",
@@ -7362,7 +7182,7 @@
 				CODE_SIGN_IDENTITY = "Apple Development";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 10000;
+				CURRENT_PROJECT_VERSION = "10000";
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = QA5XMCRV5M;
 				ENABLE_BITCODE = NO;
@@ -7423,7 +7243,7 @@
 				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES_ERROR;
 				CODE_SIGN_ENTITLEMENTS = Palace/SimplyE.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Distribution";
-				CURRENT_PROJECT_VERSION = 10000;
+				CURRENT_PROJECT_VERSION = "10000";
 				DEVELOPMENT_TEAM = 88CBA74T8K;
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = 88CBA74T8K;
 				ENABLE_BITCODE = NO;
@@ -7482,7 +7302,7 @@
 				CODE_SIGN_ENTITLEMENTS = Palace/SimplyE.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 10000;
+				CURRENT_PROJECT_VERSION = "10000";
 				DEVELOPMENT_TEAM = 88CBA74T8K;
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = 88CBA74T8K;
 				ENABLE_BITCODE = NO;
@@ -7554,8 +7374,6 @@
 				HEADER_SEARCH_PATHS = (
 					"$(inherited)",
 					"\"$(SDKROOT)/usr/include/libxml2\"",
-					"\"$(SRCROOT)/readium-sdk/Platform/Apple/RDServices\"",
-					"\"$(SRCROOT)/readium-sdk/Platform/Apple/include\"",
 					"\"$(SRCROOT)/ios-tenprintcover/TenPrintCover\"",
 					"\"$(SRCROOT)/ios-audiobook-overdrive/OverdriveProcessor\"",
 					"\"$(SRCROOT)/adept-ios\"",
@@ -7665,7 +7483,7 @@
 				CODE_SIGN_IDENTITY = "Apple Development";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 10000;
+				CURRENT_PROJECT_VERSION = "10000";
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = QA5XMCRV5M;
 				ENABLE_BITCODE = NO;
@@ -7726,7 +7544,7 @@
 				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES_ERROR;
 				CODE_SIGN_ENTITLEMENTS = Palace/SimplyE.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Distribution";
-				CURRENT_PROJECT_VERSION = 10000;
+				CURRENT_PROJECT_VERSION = "10000";
 				DEVELOPMENT_TEAM = 88CBA74T8K;
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = 88CBA74T8K;
 				ENABLE_BITCODE = NO;
@@ -7785,7 +7603,7 @@
 				CODE_SIGN_ENTITLEMENTS = Palace/SimplyE.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 10000;
+				CURRENT_PROJECT_VERSION = "10000";
 				DEVELOPMENT_TEAM = 88CBA74T8K;
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = 88CBA74T8K;
 				ENABLE_BITCODE = NO;
@@ -7857,8 +7675,6 @@
 				HEADER_SEARCH_PATHS = (
 					"$(inherited)",
 					"\"$(SDKROOT)/usr/include/libxml2\"",
-					"\"$(SRCROOT)/readium-sdk/Platform/Apple/RDServices\"",
-					"\"$(SRCROOT)/readium-sdk/Platform/Apple/include\"",
 					"\"$(SRCROOT)/ios-tenprintcover/TenPrintCover\"",
 					"\"$(SRCROOT)/ios-audiobook-overdrive/OverdriveProcessor\"",
 					"\"$(SRCROOT)/adept-ios\"",
@@ -7968,7 +7784,7 @@
 				CODE_SIGN_IDENTITY = "Apple Development";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 10000;
+				CURRENT_PROJECT_VERSION = "10000";
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = QA5XMCRV5M;
 				ENABLE_BITCODE = NO;
@@ -8029,7 +7845,7 @@
 				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES_ERROR;
 				CODE_SIGN_ENTITLEMENTS = Palace/SimplyE.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Distribution";
-				CURRENT_PROJECT_VERSION = 10000;
+				CURRENT_PROJECT_VERSION = "10000";
 				DEVELOPMENT_TEAM = 88CBA74T8K;
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = 88CBA74T8K;
 				ENABLE_BITCODE = NO;
@@ -8088,7 +7904,7 @@
 				CODE_SIGN_ENTITLEMENTS = Palace/SimplyE.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 10000;
+				CURRENT_PROJECT_VERSION = "10000";
 				DEVELOPMENT_TEAM = 88CBA74T8K;
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = 88CBA74T8K;
 				ENABLE_BITCODE = NO;
@@ -8160,8 +7976,6 @@
 				HEADER_SEARCH_PATHS = (
 					"$(inherited)",
 					"\"$(SDKROOT)/usr/include/libxml2\"",
-					"\"$(SRCROOT)/readium-sdk/Platform/Apple/RDServices\"",
-					"\"$(SRCROOT)/readium-sdk/Platform/Apple/include\"",
 					"\"$(SRCROOT)/ios-tenprintcover/TenPrintCover\"",
 					"\"$(SRCROOT)/ios-audiobook-overdrive/OverdriveProcessor\"",
 					"\"$(SRCROOT)/adept-ios\"",
@@ -8271,7 +8085,7 @@
 				CODE_SIGN_IDENTITY = "Apple Development";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 10000;
+				CURRENT_PROJECT_VERSION = "10000";
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = QA5XMCRV5M;
 				ENABLE_BITCODE = NO;
@@ -8332,7 +8146,7 @@
 				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES_ERROR;
 				CODE_SIGN_ENTITLEMENTS = Palace/SimplyE.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Distribution";
-				CURRENT_PROJECT_VERSION = 10000;
+				CURRENT_PROJECT_VERSION = "10000";
 				DEVELOPMENT_TEAM = 88CBA74T8K;
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = 88CBA74T8K;
 				ENABLE_BITCODE = NO;
@@ -8391,7 +8205,7 @@
 				CODE_SIGN_ENTITLEMENTS = Palace/SimplyE.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 10000;
+				CURRENT_PROJECT_VERSION = "10000";
 				DEVELOPMENT_TEAM = 88CBA74T8K;
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = 88CBA74T8K;
 				ENABLE_BITCODE = NO;
@@ -8463,8 +8277,6 @@
 				HEADER_SEARCH_PATHS = (
 					"$(inherited)",
 					"\"$(SDKROOT)/usr/include/libxml2\"",
-					"\"$(SRCROOT)/readium-sdk/Platform/Apple/RDServices\"",
-					"\"$(SRCROOT)/readium-sdk/Platform/Apple/include\"",
 					"\"$(SRCROOT)/ios-tenprintcover/TenPrintCover\"",
 					"\"$(SRCROOT)/ios-audiobook-overdrive/OverdriveProcessor\"",
 					"\"$(SRCROOT)/adept-ios\"",
@@ -8529,8 +8341,6 @@
 				HEADER_SEARCH_PATHS = (
 					"$(inherited)",
 					"\"$(SDKROOT)/usr/include/libxml2\"",
-					"\"$(SRCROOT)/readium-sdk/Platform/Apple/RDServices\"",
-					"\"$(SRCROOT)/readium-sdk/Platform/Apple/include\"",
 					"\"$(SRCROOT)/ios-tenprintcover/TenPrintCover\"",
 					"\"$(SRCROOT)/ios-audiobook-overdrive/OverdriveProcessor\"",
 					"\"$(SRCROOT)/adept-ios\"",
@@ -8594,8 +8404,6 @@
 				HEADER_SEARCH_PATHS = (
 					"$(inherited)",
 					"\"$(SDKROOT)/usr/include/libxml2\"",
-					"\"$(SRCROOT)/readium-sdk/Platform/Apple/RDServices\"",
-					"\"$(SRCROOT)/readium-sdk/Platform/Apple/include\"",
 					"\"$(SRCROOT)/ios-tenprintcover/TenPrintCover\"",
 					"\"$(SRCROOT)/ios-audiobook-overdrive/OverdriveProcessor\"",
 					"\"$(SRCROOT)/adept-ios\"",
@@ -8644,7 +8452,7 @@
 				CODE_SIGN_IDENTITY = "Apple Development";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 10000;
+				CURRENT_PROJECT_VERSION = "10000";
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = QA5XMCRV5M;
 				ENABLE_BITCODE = NO;
@@ -8706,7 +8514,7 @@
 				CODE_SIGN_IDENTITY = "Apple Development";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 10000;
+				CURRENT_PROJECT_VERSION = "10000";
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = QA5XMCRV5M;
 				ENABLE_BITCODE = NO;
@@ -8766,7 +8574,7 @@
 				CODE_SIGN_ENTITLEMENTS = Palace/PalaceDebug.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 10000;
+				CURRENT_PROJECT_VERSION = "10000";
 				DEVELOPMENT_TEAM = "";
 				ENABLE_BITCODE = NO;
 				FRAMEWORK_SEARCH_PATHS = (
@@ -8823,7 +8631,7 @@
 				CODE_SIGN_ENTITLEMENTS = Palace/SimplyE.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 10000;
+				CURRENT_PROJECT_VERSION = "10000";
 				DEVELOPMENT_TEAM = 88CBA74T8K;
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = 88CBA74T8K;
 				ENABLE_BITCODE = NO;
@@ -9008,7 +8816,7 @@
 				CODE_SIGN_IDENTITY = "Apple Development";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "Apple Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 10000;
+				CURRENT_PROJECT_VERSION = "10000";
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = 88CBA74T8K;
 				ENABLE_BITCODE = NO;
@@ -9068,7 +8876,7 @@
 				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES_ERROR;
 				CODE_SIGN_ENTITLEMENTS = Palace/SimplyE.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Distribution";
-				CURRENT_PROJECT_VERSION = 10000;
+				CURRENT_PROJECT_VERSION = "10000";
 				DEVELOPMENT_TEAM = 88CBA74T8K;
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = 88CBA74T8K;
 				ENABLE_BITCODE = NO;

--- a/Palace.xcodeproj/xcshareddata/xcschemes/Ekirjasto.xcscheme
+++ b/Palace.xcodeproj/xcshareddata/xcschemes/Ekirjasto.xcscheme
@@ -56,7 +56,7 @@
       </Testables>
    </TestAction>
    <LaunchAction
-      buildConfiguration = "Debug-dev"
+      buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       launchStyle = "0"

--- a/Palace/AppInfrastructure/TPPAppDelegate+Extensions.swift
+++ b/Palace/AppInfrastructure/TPPAppDelegate+Extensions.swift
@@ -10,7 +10,17 @@ import Foundation
 
 extension TPPAppDelegate {
   func topViewController(_ viewController: UIViewController? = nil) -> UIViewController? {
-    guard let controller = viewController ?? UIApplication.shared.windows.first(where: { $0.isKeyWindow })?.rootViewController else {
+    let keyWindow: UIWindow? = {
+      if #available(iOS 15.0, *) {
+        return UIApplication.shared.connectedScenes
+          .compactMap { $0 as? UIWindowScene }
+          .flatMap { $0.windows }
+          .first { $0.isKeyWindow }
+      } else {
+        return UIApplication.shared.windows.first { $0.isKeyWindow }
+      }
+    }()
+    guard let controller = viewController ?? keyWindow?.rootViewController else {
       return nil
     }
     

--- a/Palace/AppInfrastructure/TPPAppDelegate.swift
+++ b/Palace/AppInfrastructure/TPPAppDelegate.swift
@@ -48,6 +48,7 @@ class TPPAppDelegate: UIResponder, UIApplicationDelegate {
     // If we use SceneDelegate now, the app crashes during TPPRootTabBarController.shared initialization.
     // There can be other places in code that use TPPAppDelegate.window property.
     window = UIWindow()
+    window?.backgroundColor = TPPConfiguration.backgroundColor()
     window?.tintColor = TPPConfiguration.mainColor()
     window?.tintAdjustmentMode = .normal
     window?.makeKeyAndVisible()
@@ -142,27 +143,26 @@ class TPPAppDelegate: UIResponder, UIApplicationDelegate {
     // Set the appearance of the tab bar (the bottom bar in app)
     // Use the tabBarAppearance already defined for the tab bar
     
-    UITabBar.appearance().standardAppearance = tabBarAppearance
-    UITabBar.appearance().tintColor = TPPConfiguration.compatiblePrimaryColor()
-    UITabBar.appearance().backgroundColor = TPPConfiguration.backgroundColor()
-    
-    
-    // UINavigationBar
-    // Set the appearance of the navigation bar (the top bar in app)
-    // Two size variations exist:
-    //      standardAppearance = used if navigation bar is currently of normal (standard) height
-    //      compactAppearance = used if small navigation bar is shown (iPhone in landscape)
-    // Standard and compact apperances are used when user is scrolling down the content in view,
-    // otherwise the scroll edge apperances are used (for example if there is no scrollable content in view)
-    //      scrollEdgeAppearance = used when view is scrolled to top (content top is "touching" the navigation bar)
-    
-    UINavigationBar.appearance().tintColor = TPPConfiguration.iconColor()
-    UINavigationBar.appearance().standardAppearance = TPPConfiguration.defaultAppearance()
-    UINavigationBar.appearance().compactAppearance = TPPConfiguration.defaultAppearance()
-    UINavigationBar.appearance().scrollEdgeAppearance = TPPConfiguration.defaultAppearance()
-    
-    if #available(iOS 15.0, *) {
-      UINavigationBar.appearance().compactScrollEdgeAppearance = TPPConfiguration.defaultAppearance()
+    if #available(iOS 26, *) {
+      // On iOS 26+, let Liquid Glass handle tab bar and navigation bar appearance.
+      // Only set tint colors to preserve branding.
+      UITabBar.appearance().tintColor = TPPConfiguration.compatiblePrimaryColor()
+      UINavigationBar.appearance().tintColor = TPPConfiguration.iconColor()
+    } else {
+      UITabBar.appearance().standardAppearance = tabBarAppearance
+      UITabBar.appearance().tintColor = TPPConfiguration.compatiblePrimaryColor()
+      UITabBar.appearance().backgroundColor = TPPConfiguration.backgroundColor()
+
+      // UINavigationBar
+      // Set the appearance of the navigation bar (the top bar in app)
+      UINavigationBar.appearance().tintColor = TPPConfiguration.iconColor()
+      UINavigationBar.appearance().standardAppearance = TPPConfiguration.defaultAppearance()
+      UINavigationBar.appearance().compactAppearance = TPPConfiguration.defaultAppearance()
+      UINavigationBar.appearance().scrollEdgeAppearance = TPPConfiguration.defaultAppearance()
+
+      if #available(iOS 15.0, *) {
+        UINavigationBar.appearance().compactScrollEdgeAppearance = TPPConfiguration.defaultAppearance()
+      }
     }
 
     TPPErrorLogger.logNewAppLaunch()

--- a/Palace/AppInfrastructure/TPPAppDelegate.swift
+++ b/Palace/AppInfrastructure/TPPAppDelegate.swift
@@ -145,9 +145,16 @@ class TPPAppDelegate: UIResponder, UIApplicationDelegate {
     
     if #available(iOS 26, *) {
       // On iOS 26+, let Liquid Glass handle tab bar and navigation bar appearance.
-      // Only set tint colors to preserve branding.
+      // Set tint colors to preserve branding and use default background
+      // to get a solid nav bar (matching the standard iOS behavior).
       UITabBar.appearance().tintColor = TPPConfiguration.compatiblePrimaryColor()
       UINavigationBar.appearance().tintColor = TPPConfiguration.iconColor()
+      let navAppearance = UINavigationBarAppearance()
+      navAppearance.configureWithDefaultBackground()
+      UINavigationBar.appearance().standardAppearance = navAppearance
+      UINavigationBar.appearance().scrollEdgeAppearance = navAppearance
+      UINavigationBar.appearance().compactAppearance = navAppearance
+      UINavigationBar.appearance().compactScrollEdgeAppearance = navAppearance
     } else {
       UITabBar.appearance().standardAppearance = tabBarAppearance
       UITabBar.appearance().tintColor = TPPConfiguration.compatiblePrimaryColor()

--- a/Palace/Book/UI/BookDetailView/TPPBookDetailTableView.swift
+++ b/Palace/Book/UI/BookDetailView/TPPBookDetailTableView.swift
@@ -136,9 +136,7 @@ private let standardCellHeight: CGFloat = 44.0
       books += lane.books as! [TPPBook]
     }
 
-    UIApplication.shared.isNetworkActivityIndicatorVisible = true
     TPPBookRegistry.shared.thumbnailImages(forBooks: Set(books.map{$0})) { (bookIdentifierToImages) in
-      UIApplication.shared.isNetworkActivityIndicatorVisible = false
       var index: UInt = 0
       for lane in feed.lanes as! [TPPCatalogLane] {
         if let laneCell = TPPCatalogLaneCell(laneIndex: index, books: lane.books,

--- a/Palace/Catalog/Feed/Grouped/TPPCatalogGroupedFeedViewController.m
+++ b/Palace/Catalog/Feed/Grouped/TPPCatalogGroupedFeedViewController.m
@@ -98,6 +98,11 @@ static CGFloat const kTableViewCrossfadeDuration = 0.3;
   self.tableView.allowsSelection = NO;
   if (@available(iOS 26, *)) {
     self.tableView.contentInsetAdjustmentBehavior = UIScrollViewContentInsetAdjustmentAutomatic;
+    if (UIDevice.currentDevice.userInterfaceIdiom == UIUserInterfaceIdiomPad) {
+      // Hide the top scroll edge fade so section headers near the top
+      // are not blurred by the Liquid Glass nav bar effect.
+      self.tableView.topEdgeEffect.hidden = YES;
+    }
   } else if (@available(iOS 11.0, *)) {
     self.tableView.contentInsetAdjustmentBehavior = UIScrollViewContentInsetAdjustmentNever;
   }
@@ -575,15 +580,32 @@ viewForHeaderInSection:(NSInteger const)section
 
   UIViewController *const viewController = [[TPPCatalogFeedViewController alloc]
                                             initWithURL:urlToLoad];
-  
-  UILabel *label = [[UILabel alloc] initWithFrame:CGRectMake(0, 0, self.view.frame.size.width, 150)];
-  label.numberOfLines = 0;
-  label.lineBreakMode = NSLineBreakByWordWrapping;
-  label.textAlignment = NSTextAlignmentCenter;
-  label.font = [UIFont semiBoldPalaceFontOfSize: 16];
-  label.text = lane.title;
-  label.accessibilityTraits = UIAccessibilityTraitHeader;
-  viewController.navigationItem.titleView = label;
+
+  BOOL useStandardTitle = NO;
+  if (@available(iOS 26, *)) {
+    if (UIDevice.currentDevice.userInterfaceIdiom == UIUserInterfaceIdiomPad) {
+      useStandardTitle = YES;
+    }
+  }
+
+  if (useStandardTitle) {
+    // On iPad iOS 26, use the standard title which centers properly
+    // in the Liquid Glass navigation bar.
+    viewController.title = lane.title;
+    // Only prevent extending under the top bar so content
+    // doesn't show through the transparent tab bar area.
+    // Keep bottom edge extended so content reaches the screen edge.
+    viewController.edgesForExtendedLayout = UIRectEdgeBottom | UIRectEdgeLeft | UIRectEdgeRight;
+  } else {
+    UILabel *label = [[UILabel alloc] initWithFrame:CGRectMake(0, 0, self.view.frame.size.width, 150)];
+    label.numberOfLines = 0;
+    label.lineBreakMode = NSLineBreakByWordWrapping;
+    label.textAlignment = NSTextAlignmentCenter;
+    label.font = [UIFont semiBoldPalaceFontOfSize: 16];
+    label.text = lane.title;
+    label.accessibilityTraits = UIAccessibilityTraitHeader;
+    viewController.navigationItem.titleView = label;
+  }
 
   [self.navigationController pushViewController:viewController animated:YES];
 }

--- a/Palace/Catalog/Feed/Grouped/TPPCatalogGroupedFeedViewController.m
+++ b/Palace/Catalog/Feed/Grouped/TPPCatalogGroupedFeedViewController.m
@@ -81,11 +81,9 @@ static CGFloat const kTableViewCrossfadeDuration = 0.3;
 
   UITableViewStyle tableStyle = UITableViewStylePlain;
   if (@available(iOS 26, *)) {
-    if (UIDevice.currentDevice.userInterfaceIdiom == UIUserInterfaceIdiomPad) {
-      // Grouped style disables sticky section headers on iPad,
-      // which avoids opaque headers clashing with Liquid Glass nav bar.
-      tableStyle = UITableViewStyleGrouped;
-    }
+    // Grouped style disables sticky section headers,
+    // which avoids opaque headers clashing with the nav bar area.
+    tableStyle = UITableViewStyleGrouped;
   }
   self.tableView = [[UITableView alloc] initWithFrame:self.view.bounds style:tableStyle];
   self.tableView.autoresizingMask = (UIViewAutoresizingFlexibleWidth |
@@ -97,11 +95,15 @@ static CGFloat const kTableViewCrossfadeDuration = 0.3;
   self.tableView.separatorStyle = UITableViewCellSeparatorStyleNone;
   self.tableView.allowsSelection = NO;
   if (@available(iOS 26, *)) {
-    self.tableView.contentInsetAdjustmentBehavior = UIScrollViewContentInsetAdjustmentAutomatic;
     if (UIDevice.currentDevice.userInterfaceIdiom == UIUserInterfaceIdiomPad) {
+      self.tableView.contentInsetAdjustmentBehavior = UIScrollViewContentInsetAdjustmentAutomatic;
       // Hide the top scroll edge fade so section headers near the top
       // are not blurred by the Liquid Glass nav bar effect.
       self.tableView.topEdgeEffect.hidden = YES;
+    } else {
+      // On iPhone iOS 26, use Never so the table doesn't extend
+      // under the nav bar (matching pre-iOS 26 behavior).
+      self.tableView.contentInsetAdjustmentBehavior = UIScrollViewContentInsetAdjustmentNever;
     }
   } else if (@available(iOS 11.0, *)) {
     self.tableView.contentInsetAdjustmentBehavior = UIScrollViewContentInsetAdjustmentNever;
@@ -209,10 +211,14 @@ static CGFloat const kTableViewCrossfadeDuration = 0.3;
   [super didMoveToParentViewController:parent];
 
   if(parent) {
-    // On iOS 26, contentInsetAdjustmentBehavior is Automatic,
-    // so the system handles insets. Skip manual inset calculation.
+    // On iPad iOS 26, the facet bar is hidden (moved to nav bar) and
+    // contentInsetAdjustmentBehavior handles insets. Skip manual calculation.
+    // On iPhone iOS 26, the facet bar is still visible, so we still
+    // need manual insets to push the table below it.
     if (@available(iOS 26, *)) {
-      return;
+      if (UIDevice.currentDevice.userInterfaceIdiom == UIUserInterfaceIdiomPad) {
+        return;
+      }
     }
 
     CGFloat top = parent.topLayoutGuide.length;
@@ -376,14 +382,9 @@ viewForHeaderInSection:(NSInteger const)section
   UIView *const view = [[UIView alloc] initWithFrame:frame];
   view.autoresizingMask = UIViewAutoresizingFlexibleWidth;
   if (@available(iOS 26, *)) {
-    if (UIDevice.currentDevice.userInterfaceIdiom == UIUserInterfaceIdiomPad) {
-      // On iPad, use a clear background so headers blend with Liquid Glass
-      view.backgroundColor = UIColor.clearColor;
-    } else {
-      view.backgroundColor = [TPPConfiguration backgroundColor];
-      // Lock to current interface style so Liquid Glass cannot flip it mid-scroll
-      view.overrideUserInterfaceStyle = self.traitCollection.userInterfaceStyle;
-    }
+    // Use clear background — grouped style with non-sticky headers
+    // means they scroll with content and don't need a background.
+    view.backgroundColor = UIColor.clearColor;
   } else {
     view.backgroundColor = [[TPPConfiguration backgroundColor] colorWithAlphaComponent:0.9];
   }
@@ -583,18 +584,13 @@ viewForHeaderInSection:(NSInteger const)section
 
   BOOL useStandardTitle = NO;
   if (@available(iOS 26, *)) {
-    if (UIDevice.currentDevice.userInterfaceIdiom == UIUserInterfaceIdiomPad) {
-      useStandardTitle = YES;
-    }
+    useStandardTitle = YES;
   }
 
   if (useStandardTitle) {
-    // On iPad iOS 26, use the standard title which centers properly
-    // in the Liquid Glass navigation bar.
+    // On iOS 26, use the standard title and prevent extending under
+    // the top bar so content doesn't show through.
     viewController.title = lane.title;
-    // Only prevent extending under the top bar so content
-    // doesn't show through the transparent tab bar area.
-    // Keep bottom edge extended so content reaches the screen edge.
     viewController.edgesForExtendedLayout = UIRectEdgeBottom | UIRectEdgeLeft | UIRectEdgeRight;
   } else {
     UILabel *label = [[UILabel alloc] initWithFrame:CGRectMake(0, 0, self.view.frame.size.width, 150)];

--- a/Palace/Catalog/Feed/Grouped/TPPCatalogGroupedFeedViewController.m
+++ b/Palace/Catalog/Feed/Grouped/TPPCatalogGroupedFeedViewController.m
@@ -75,10 +75,10 @@ static CGFloat const kTableViewCrossfadeDuration = 0.3;
   [super viewDidLoad];
   
   self.view.backgroundColor = [TPPConfiguration backgroundColor];
-  
+
   self.refreshControl = [[UIRefreshControl alloc] init];
   [self.refreshControl addTarget:self action:@selector(userDidRefresh:) forControlEvents:UIControlEventValueChanged];
-  
+
   self.tableView = [[UITableView alloc] initWithFrame:self.view.bounds style:UITableViewStylePlain];
   self.tableView.autoresizingMask = (UIViewAutoresizingFlexibleWidth |
                                      UIViewAutoresizingFlexibleHeight);
@@ -88,7 +88,9 @@ static CGFloat const kTableViewCrossfadeDuration = 0.3;
   self.tableView.delegate = self;
   self.tableView.separatorStyle = UITableViewCellSeparatorStyleNone;
   self.tableView.allowsSelection = NO;
-  if (@available(iOS 11.0, *)) {
+  if (@available(iOS 26, *)) {
+    self.tableView.contentInsetAdjustmentBehavior = UIScrollViewContentInsetAdjustmentAutomatic;
+  } else if (@available(iOS 11.0, *)) {
     self.tableView.contentInsetAdjustmentBehavior = UIScrollViewContentInsetAdjustmentNever;
   }
   [self.tableView addSubview:self.refreshControl];
@@ -135,16 +137,22 @@ static CGFloat const kTableViewCrossfadeDuration = 0.3;
 - (void)didMoveToParentViewController:(UIViewController *)parent
 {
   [super didMoveToParentViewController:parent];
-  
+
   if(parent) {
+    // On iOS 26, contentInsetAdjustmentBehavior is Automatic,
+    // so the system handles insets. Skip manual inset calculation.
+    if (@available(iOS 26, *)) {
+      return;
+    }
+
     CGFloat top = parent.topLayoutGuide.length;
-    
+
     if (self.facetBarView.frame.size.height > 0) {
       top = CGRectGetMaxY(self.facetBarView.frame) + kTableViewInsetAdjustmentWithEntryPoints;
     }
-    
+
     CGFloat bottom = parent.bottomLayoutGuide.length;
-    
+
     UIEdgeInsets insets = UIEdgeInsetsMake(top, 0, bottom, 0);
     self.tableView.contentInset = insets;
     self.tableView.scrollIndicatorInsets = insets;
@@ -297,7 +305,13 @@ viewForHeaderInSection:(NSInteger const)section
   CGRect const frame = CGRectMake(0, 0, CGRectGetWidth(self.tableView.frame), kSectionHeaderHeight);
   UIView *const view = [[UIView alloc] initWithFrame:frame];
   view.autoresizingMask = UIViewAutoresizingFlexibleWidth;
-  view.backgroundColor = [[TPPConfiguration backgroundColor] colorWithAlphaComponent:0.9];
+  if (@available(iOS 26, *)) {
+    view.backgroundColor = [TPPConfiguration backgroundColor];
+    // Lock to current interface style so Liquid Glass cannot flip it mid-scroll
+    view.overrideUserInterfaceStyle = self.traitCollection.userInterfaceStyle;
+  } else {
+    view.backgroundColor = [[TPPConfiguration backgroundColor] colorWithAlphaComponent:0.9];
+  }
   
   // Creates a header button that displays the title of a category and allows the user to tap on it to view more books in that category.
   {

--- a/Palace/Catalog/Feed/Grouped/TPPCatalogGroupedFeedViewController.m
+++ b/Palace/Catalog/Feed/Grouped/TPPCatalogGroupedFeedViewController.m
@@ -79,7 +79,15 @@ static CGFloat const kTableViewCrossfadeDuration = 0.3;
   self.refreshControl = [[UIRefreshControl alloc] init];
   [self.refreshControl addTarget:self action:@selector(userDidRefresh:) forControlEvents:UIControlEventValueChanged];
 
-  self.tableView = [[UITableView alloc] initWithFrame:self.view.bounds style:UITableViewStylePlain];
+  UITableViewStyle tableStyle = UITableViewStylePlain;
+  if (@available(iOS 26, *)) {
+    if (UIDevice.currentDevice.userInterfaceIdiom == UIUserInterfaceIdiomPad) {
+      // Grouped style disables sticky section headers on iPad,
+      // which avoids opaque headers clashing with Liquid Glass nav bar.
+      tableStyle = UITableViewStyleGrouped;
+    }
+  }
+  self.tableView = [[UITableView alloc] initWithFrame:self.view.bounds style:tableStyle];
   self.tableView.autoresizingMask = (UIViewAutoresizingFlexibleWidth |
                                      UIViewAutoresizingFlexibleHeight);
   self.tableView.alpha = 0.0;
@@ -100,12 +108,27 @@ static CGFloat const kTableViewCrossfadeDuration = 0.3;
   self.facetBarView.entryPointView.dataSource = self;
   self.facetBarView.delegate = self;
   
-  [self.view addSubview:self.facetBarView];
-  
-  [self.facetBarView autoPinEdgeToSuperviewSafeArea:ALEdgeTop];// Added by Ellibs
+  // On iPad with iOS 26, move the segmented control into the navigation bar
+  // titleView so it merges with the Liquid Glass bar, and hide the facet bar.
+  BOOL useNavBarSegmentedControl = NO;
+  if (@available(iOS 26, *)) {
+    if (UIDevice.currentDevice.userInterfaceIdiom == UIUserInterfaceIdiomPad) {
+      useNavBarSegmentedControl = YES;
+    }
+  }
 
-  [self.facetBarView autoPinEdgeToSuperviewEdge:ALEdgeLeading];
-  [self.facetBarView autoPinEdgeToSuperviewEdge:ALEdgeTrailing];
+  if (useNavBarSegmentedControl) {
+    // Don't add the facet bar to the view at all on iPad iOS 26.
+    // Instead, create a segmented control in the navigation bar.
+    [self setupNavBarSegmentedControl];
+  } else {
+    [self.view addSubview:self.facetBarView];
+
+    [self.facetBarView autoPinEdgeToSuperviewSafeArea:ALEdgeTop];// Added by Ellibs
+
+    [self.facetBarView autoPinEdgeToSuperviewEdge:ALEdgeLeading];
+    [self.facetBarView autoPinEdgeToSuperviewEdge:ALEdgeTrailing];
+  }
   
   if(self.feed.openSearchURL) {
     self.navigationItem.rightBarButtonItem = [[UIBarButtonItem alloc]
@@ -132,6 +155,48 @@ static CGFloat const kTableViewCrossfadeDuration = 0.3;
   
   [self downloadImages];
   [self enable3DTouch];
+}
+
+/// On iPad iOS 26, place the entry point segmented control (All/Audiobooks/eBooks)
+/// directly in the navigation bar's titleView so it integrates with Liquid Glass.
+- (void)setupNavBarSegmentedControl
+{
+  NSArray<TPPCatalogFacet *> *facets = self.feed.entryPoints;
+  if (facets.count < 2) {
+    return;
+  }
+
+  NSMutableArray<NSString *> *titles = [NSMutableArray arrayWithCapacity:facets.count];
+  for (TPPCatalogFacet *facet in facets) {
+    if (facet.title) {
+      [titles addObject:facet.title];
+    }
+  }
+  if (titles.count < 2) {
+    return;
+  }
+
+  UISegmentedControl *segmentedControl = [[UISegmentedControl alloc] initWithItems:titles];
+  for (NSUInteger i = 0; i < facets.count; i++) {
+    if (facets[i].active) {
+      segmentedControl.selectedSegmentIndex = i;
+      break;
+    }
+  }
+  [segmentedControl addTarget:self
+                       action:@selector(navBarSegmentDidChange:)
+             forControlEvents:UIControlEventValueChanged];
+
+  self.remoteViewController.navigationItem.titleView = segmentedControl;
+}
+
+- (void)navBarSegmentDidChange:(UISegmentedControl *)sender
+{
+  NSArray<TPPCatalogFacet *> *facets = self.feed.entryPoints;
+  NSInteger index = sender.selectedSegmentIndex;
+  if (index >= 0 && index < (NSInteger)facets.count) {
+    [self entryPointViewDidSelectWithEntryPointFacet:facets[index]];
+  }
 }
 
 - (void)didMoveToParentViewController:(UIViewController *)parent
@@ -306,9 +371,14 @@ viewForHeaderInSection:(NSInteger const)section
   UIView *const view = [[UIView alloc] initWithFrame:frame];
   view.autoresizingMask = UIViewAutoresizingFlexibleWidth;
   if (@available(iOS 26, *)) {
-    view.backgroundColor = [TPPConfiguration backgroundColor];
-    // Lock to current interface style so Liquid Glass cannot flip it mid-scroll
-    view.overrideUserInterfaceStyle = self.traitCollection.userInterfaceStyle;
+    if (UIDevice.currentDevice.userInterfaceIdiom == UIUserInterfaceIdiomPad) {
+      // On iPad, use a clear background so headers blend with Liquid Glass
+      view.backgroundColor = UIColor.clearColor;
+    } else {
+      view.backgroundColor = [TPPConfiguration backgroundColor];
+      // Lock to current interface style so Liquid Glass cannot flip it mid-scroll
+      view.overrideUserInterfaceStyle = self.traitCollection.userInterfaceStyle;
+    }
   } else {
     view.backgroundColor = [[TPPConfiguration backgroundColor] colorWithAlphaComponent:0.9];
   }

--- a/Palace/Catalog/Feed/Grouped/TPPCatalogGroupedFeedViewController.m
+++ b/Palace/Catalog/Feed/Grouped/TPPCatalogGroupedFeedViewController.m
@@ -99,7 +99,9 @@ static CGFloat const kTableViewCrossfadeDuration = 0.3;
       self.tableView.contentInsetAdjustmentBehavior = UIScrollViewContentInsetAdjustmentAutomatic;
       // Hide the top scroll edge fade so section headers near the top
       // are not blurred by the Liquid Glass nav bar effect.
+#if __IPHONE_OS_VERSION_MAX_ALLOWED >= 260000
       self.tableView.topEdgeEffect.hidden = YES;
+#endif
     } else {
       // On iPhone iOS 26, use Never so the table doesn't extend
       // under the nav bar (matching pre-iOS 26 behavior).

--- a/Palace/Catalog/Navigation/TPPCatalogNavigationController.m
+++ b/Palace/Catalog/Navigation/TPPCatalogNavigationController.m
@@ -47,14 +47,28 @@
   // at the top of the view, because the actual view title may be hidden.
   // Title label was added because iPads using iOS 18 or higher
   // use the floating tab bar with a regular horizontal size class.
-  UILabel *titleViewlabel = [[UILabel alloc] initWithFrame:CGRectMake(0, 0, self.view.frame.size.width, 150)];
-  titleViewlabel.numberOfLines = 0;
-  titleViewlabel.lineBreakMode = NSLineBreakByWordWrapping;
-  titleViewlabel.textAlignment = NSTextAlignmentCenter;
-  titleViewlabel.font = [UIFont semiBoldPalaceFontOfSize: 16];
-  titleViewlabel.text = NSLocalizedString(@"Browse Books", nil);
-  titleViewlabel.accessibilityTraits = UIAccessibilityTraitHeader;
-  self.viewController.navigationItem.titleView = titleViewlabel;
+  // On iPad iOS 26+, the floating tab bar already shows the title,
+  // and the segmented control replaces the titleView in the grouped feed.
+  BOOL iPadIOS26 = NO;
+  if (@available(iOS 26, *)) {
+    if (UIDevice.currentDevice.userInterfaceIdiom == UIUserInterfaceIdiomPad) {
+      iPadIOS26 = YES;
+      // Prevent the view from extending under the nav bar, so the
+      // view's background color creates a solid area below the tab bar,
+      // matching the SwiftUI tabs (My Books, Favorites, etc.).
+      self.viewController.edgesForExtendedLayout = UIRectEdgeBottom | UIRectEdgeLeft | UIRectEdgeRight;
+    }
+  }
+  if (!iPadIOS26) {
+    UILabel *titleViewlabel = [[UILabel alloc] initWithFrame:CGRectMake(0, 0, self.view.frame.size.width, 150)];
+    titleViewlabel.numberOfLines = 0;
+    titleViewlabel.lineBreakMode = NSLineBreakByWordWrapping;
+    titleViewlabel.textAlignment = NSTextAlignmentCenter;
+    titleViewlabel.font = [UIFont semiBoldPalaceFontOfSize: 16];
+    titleViewlabel.text = NSLocalizedString(@"Browse Books", nil);
+    titleViewlabel.accessibilityTraits = UIAccessibilityTraitHeader;
+    self.viewController.navigationItem.titleView = titleViewlabel;
+  }
 
 #ifdef SIMPLYE
   [self setNavigationLeftBarButtonForVC:self.viewController];
@@ -185,6 +199,21 @@
 - (void)viewDidLoad
 {
   [super viewDidLoad];
+
+  // On iPad iOS 26, hide the nav bar background to match the SwiftUI tabs
+  // (My Books, Favorites) which use .toolbarBackground(.hidden).
+  // The view's own backgroundColor provides the solid area below the tab bar.
+  if (@available(iOS 26, *)) {
+    if (UIDevice.currentDevice.userInterfaceIdiom == UIUserInterfaceIdiomPad) {
+      UINavigationBarAppearance *appearance = [[UINavigationBarAppearance alloc] init];
+      [appearance configureWithTransparentBackground];
+      self.navigationBar.standardAppearance = appearance;
+      self.navigationBar.scrollEdgeAppearance = appearance;
+      self.navigationBar.compactAppearance = appearance;
+      self.navigationBar.compactScrollEdgeAppearance = appearance;
+    }
+  }
+
   TPPSettings *settings = [TPPSettings sharedSettings];
   if (settings.userHasSeenWelcomeScreen) {
     Account *account = [[AccountsManager sharedInstance] currentAccount];

--- a/Palace/Catalog/Navigation/TPPCatalogNavigationController.m
+++ b/Palace/Catalog/Navigation/TPPCatalogNavigationController.m
@@ -49,17 +49,13 @@
   // use the floating tab bar with a regular horizontal size class.
   // On iPad iOS 26+, the floating tab bar already shows the title,
   // and the segmented control replaces the titleView in the grouped feed.
-  BOOL iPadIOS26 = NO;
+  BOOL iOS26 = NO;
   if (@available(iOS 26, *)) {
-    if (UIDevice.currentDevice.userInterfaceIdiom == UIUserInterfaceIdiomPad) {
-      iPadIOS26 = YES;
-      // Prevent the view from extending under the nav bar, so the
-      // view's background color creates a solid area below the tab bar,
-      // matching the SwiftUI tabs (My Books, Favorites, etc.).
-      self.viewController.edgesForExtendedLayout = UIRectEdgeBottom | UIRectEdgeLeft | UIRectEdgeRight;
-    }
+    iOS26 = YES;
+    // Prevent the view from extending under the nav bar.
+    self.viewController.edgesForExtendedLayout = UIRectEdgeBottom | UIRectEdgeLeft | UIRectEdgeRight;
   }
-  if (!iPadIOS26) {
+  if (!iOS26) {
     UILabel *titleViewlabel = [[UILabel alloc] initWithFrame:CGRectMake(0, 0, self.view.frame.size.width, 150)];
     titleViewlabel.numberOfLines = 0;
     titleViewlabel.lineBreakMode = NSLineBreakByWordWrapping;
@@ -200,6 +196,9 @@
 {
   [super viewDidLoad];
 
+  // Prevent the navigation bar from auto-hiding on scroll
+  self.hidesBarsOnSwipe = NO;
+
   // On iPad iOS 26, hide the nav bar background to match the SwiftUI tabs
   // (My Books, Favorites) which use .toolbarBackground(.hidden).
   // The view's own backgroundColor provides the solid area below the tab bar.
@@ -207,6 +206,16 @@
     if (UIDevice.currentDevice.userInterfaceIdiom == UIUserInterfaceIdiomPad) {
       UINavigationBarAppearance *appearance = [[UINavigationBarAppearance alloc] init];
       [appearance configureWithTransparentBackground];
+      self.navigationBar.standardAppearance = appearance;
+      self.navigationBar.scrollEdgeAppearance = appearance;
+      self.navigationBar.compactAppearance = appearance;
+      self.navigationBar.compactScrollEdgeAppearance = appearance;
+    } else {
+      // On iPhone iOS 26, force an opaque nav bar so content
+      // doesn't show through the Liquid Glass translucency.
+      UINavigationBarAppearance *appearance = [[UINavigationBarAppearance alloc] init];
+      [appearance configureWithOpaqueBackground];
+      appearance.backgroundColor = [TPPConfiguration backgroundColor];
       self.navigationBar.standardAppearance = appearance;
       self.navigationBar.scrollEdgeAppearance = appearance;
       self.navigationBar.compactAppearance = appearance;

--- a/Palace/EkirjastoDigitalMagazine/EkirjastoMagazineNavigationController.swift
+++ b/Palace/EkirjastoDigitalMagazine/EkirjastoMagazineNavigationController.swift
@@ -11,12 +11,12 @@ class EkirjastoMagazineNavigationController: TPPLibraryNavigationController {
   override init(rootViewController: UIViewController) {
     super.init(rootViewController: rootViewController)
 
-    // On iPad iOS 26, show the navigation bar so the floating tab bar
-    // does not overlap the web content.
+    navigationBar.isHidden = true
+
+    // On iPad iOS 26, add extra top inset so the web content clears
+    // the floating tab bar. The web app renders its own navigation UI.
     if #available(iOS 26, *), UIDevice.current.userInterfaceIdiom == .pad {
-      navigationBar.isHidden = false
-    } else {
-      navigationBar.isHidden = true
+      rootViewController.additionalSafeAreaInsets = UIEdgeInsets(top: 50, left: 0, bottom: 0, right: 0)
     }
     
     tabBarItem.title = NSLocalizedString("Magazines", comment: "")

--- a/Palace/EkirjastoDigitalMagazine/EkirjastoMagazineNavigationController.swift
+++ b/Palace/EkirjastoDigitalMagazine/EkirjastoMagazineNavigationController.swift
@@ -10,8 +10,14 @@ class EkirjastoMagazineNavigationController: TPPLibraryNavigationController {
 
   override init(rootViewController: UIViewController) {
     super.init(rootViewController: rootViewController)
-    
-    navigationBar.isHidden = true
+
+    // On iPad iOS 26, show the navigation bar so the floating tab bar
+    // does not overlap the web content.
+    if #available(iOS 26, *), UIDevice.current.userInterfaceIdiom == .pad {
+      navigationBar.isHidden = false
+    } else {
+      navigationBar.isHidden = true
+    }
     
     tabBarItem.title = NSLocalizedString("Magazines", comment: "")
     tabBarItem.image = UIImage(named: "Magazines")

--- a/Palace/MyBooks/Views/Favorites/FavoritesMainView.swift
+++ b/Palace/MyBooks/Views/Favorites/FavoritesMainView.swift
@@ -17,6 +17,7 @@ struct FavoritesMainView: View {
     ContentView
       .navigationBarItems(leading: EKirjastoButton)
       .navigationBarTitle(Strings.MyBooksView.favoritesAndReadNavTitle)
+      .modifier(HideNavBarBackgroundOnIPadIOS26())
       .onReceive(
         NotificationCenter.default.publisher(
           for: UIDevice.orientationDidChangeNotification)

--- a/Palace/MyBooks/Views/Favorites/FavoritesMainViewController.swift
+++ b/Palace/MyBooks/Views/Favorites/FavoritesMainViewController.swift
@@ -36,13 +36,18 @@ class FavoritesMainViewController: NSObject {
     // Title view label is displayed at the top of the view,
     // below the floating tab bar, for iPads running iOS 18 or higher
     // with a regular horizontal size class.
-    //The style matches the lane titles of the catalog's ungrouped view.
-    let titleViewLabel = UILabel()
-    titleViewLabel.text = Strings.MyBooksView.favoritesAndReadNavTitle
-    titleViewLabel.font = UIFont.palaceFont(ofSize: 16)
-    titleViewLabel.textAlignment = .center
-    titleViewLabel.accessibilityTraits = .header
-    hostingController.navigationItem.titleView = titleViewLabel
+    // On iPad iOS 26+, the floating tab bar already shows the title,
+    // so the extra label is redundant.
+    if #available(iOS 26, *), UIDevice.current.userInterfaceIdiom == .pad {
+      // No titleView needed — tab bar shows the title
+    } else {
+      let titleViewLabel = UILabel()
+      titleViewLabel.text = Strings.MyBooksView.favoritesAndReadNavTitle
+      titleViewLabel.font = UIFont.palaceFont(ofSize: 16)
+      titleViewLabel.textAlignment = .center
+      titleViewLabel.accessibilityTraits = .header
+      hostingController.navigationItem.titleView = titleViewLabel
+    }
 
     // Button text for returning to this view.
     // This button is displayed in book detail view and search view,

--- a/Palace/MyBooks/Views/Favorites/FavoritesMainViewController.swift
+++ b/Palace/MyBooks/Views/Favorites/FavoritesMainViewController.swift
@@ -38,8 +38,8 @@ class FavoritesMainViewController: NSObject {
     // with a regular horizontal size class.
     // On iPad iOS 26+, the floating tab bar already shows the title,
     // so the extra label is redundant.
-    if #available(iOS 26, *), UIDevice.current.userInterfaceIdiom == .pad {
-      // No titleView needed — tab bar shows the title
+    if #available(iOS 26, *) {
+      // On iOS 26, use standard nav bar title (no custom label needed)
     } else {
       let titleViewLabel = UILabel()
       titleViewLabel.text = Strings.MyBooksView.favoritesAndReadNavTitle

--- a/Palace/MyBooks/Views/LoansAndHolds/LoansAndHoldsView.swift
+++ b/Palace/MyBooks/Views/LoansAndHolds/LoansAndHoldsView.swift
@@ -4,15 +4,33 @@
 
 import SwiftUI
 
+/// Hides the navigation bar background on iPad iOS 26 so Liquid Glass
+/// shows through consistently across all tabs.
+struct HideNavBarBackgroundOnIPadIOS26: ViewModifier {
+  func body(content: Content) -> some View {
+    if #available(iOS 26, *), UIDevice.current.userInterfaceIdiom == .pad {
+      content
+        .toolbarBackground(.hidden, for: .navigationBar)
+    } else {
+      content
+    }
+  }
+}
+
+/// Shared selection state that can be driven from both SwiftUI and UIKit.
+class LoansAndHoldsSelection: ObservableObject {
+  @Published var selectedSubview = "Loans"
+}
+
 struct LoansAndHoldsView: View {
 
   @State private var orientation: UIDeviceOrientation = UIDevice.current
     .orientation
   @ObservedObject var loansViewModel: LoansViewModel
   @ObservedObject var holdsViewModel: HoldsViewModel
+  @ObservedObject var selection: LoansAndHoldsSelection
 
   var subviews = ["Loans", "Holds"]
-  @State private var selectedSubview = "Loans"
 
   let backgroundColor: Color = Color(TPPConfiguration.backgroundColor())
 
@@ -21,6 +39,7 @@ struct LoansAndHoldsView: View {
     ContentView
       .navigationBarItems(leading: EKirjastoButton)
       .navigationBarTitle(Strings.MyBooksView.loansAndHoldsNavTitle)
+      .modifier(HideNavBarBackgroundOnIPadIOS26())
       .onReceive(
         NotificationCenter.default.publisher(
           for: UIDevice.orientationDidChangeNotification)
@@ -32,9 +51,13 @@ struct LoansAndHoldsView: View {
 
   @ViewBuilder private var ContentView: some View {
 
-    SegmentedPicker
+    // On iPad iOS 26, the segmented control is in the navigation bar titleView,
+    // so hide the in-content picker.
+    if !useNavBarSegmentedControl {
+      SegmentedPicker
+    }
 
-    switch selectedSubview {
+    switch selection.selectedSubview {
     case "Loans":
       LoansSubview
     case "Holds":
@@ -43,6 +66,13 @@ struct LoansAndHoldsView: View {
       LoansSubview
     }
 
+  }
+
+  private var useNavBarSegmentedControl: Bool {
+    if #available(iOS 26, *), UIDevice.current.userInterfaceIdiom == .pad {
+      return true
+    }
+    return false
   }
 
   @ViewBuilder private var EKirjastoButton: some View {
@@ -59,7 +89,7 @@ struct LoansAndHoldsView: View {
     VStack {
       Picker(
         "View list of books on loan or list of books on hold",
-        selection: $selectedSubview
+        selection: $selection.selectedSubview
       ) {
         //Add the localized title for the holds and loans buttons
         ForEach(subviews, id: \.self) {

--- a/Palace/MyBooks/Views/LoansAndHolds/LoansAndHoldsViewController.swift
+++ b/Palace/MyBooks/Views/LoansAndHolds/LoansAndHoldsViewController.swift
@@ -16,10 +16,12 @@ class LoansAndHoldsViewController: NSObject {
     // LoansAndHoldsMainView (a SwiftUI view) into the app's UIKit view hierarchy.
     // LoansViewModel and HoldsViewModel contain the main logic for these subviews,
     // and we pass them as parameters for the LoansAndHoldsMainView
+    let selection = LoansAndHoldsSelection()
     let hostingController = UIHostingController(
       rootView: LoansAndHoldsView(
         loansViewModel: LoansViewModel(),
-        holdsViewModel: HoldsViewModel()
+        holdsViewModel: HoldsViewModel(),
+        selection: selection
       )
     )
 
@@ -36,13 +38,29 @@ class LoansAndHoldsViewController: NSObject {
     // Title view label is displayed at the top of the view,
     // below the floating tab bar, for iPads running iOS 18 or higher
     // with a regular horizontal size class.
-    //The style matches the lane titles of the catalog's ungrouped view.
-    let titleViewLabel = UILabel()
-    titleViewLabel.text = Strings.MyBooksView.loansAndHoldsNavTitle
-    titleViewLabel.font = UIFont.palaceFont(ofSize: 16)
-    titleViewLabel.textAlignment = .center
-    titleViewLabel.accessibilityTraits = .header
-    hostingController.navigationItem.titleView = titleViewLabel
+    // On iPad iOS 26+, the floating tab bar already shows the title,
+    // so the extra label is redundant.
+    if #available(iOS 26, *), UIDevice.current.userInterfaceIdiom == .pad {
+      // Place Loans/Holds segmented control in the nav bar titleView
+      // to match the Browse Books style with Liquid Glass.
+      let segmentedControl = UISegmentedControl(items: [
+        Strings.MyBooksView.loansNavTitle,
+        Strings.MyBooksView.holdsNavTitle
+      ])
+      segmentedControl.selectedSegmentIndex = 0
+      segmentedControl.addAction(UIAction { [weak selection] action in
+        guard let control = action.sender as? UISegmentedControl else { return }
+        selection?.selectedSubview = control.selectedSegmentIndex == 0 ? "Loans" : "Holds"
+      }, for: .valueChanged)
+      hostingController.navigationItem.titleView = segmentedControl
+    } else {
+      let titleViewLabel = UILabel()
+      titleViewLabel.text = Strings.MyBooksView.loansAndHoldsNavTitle
+      titleViewLabel.font = UIFont.palaceFont(ofSize: 16)
+      titleViewLabel.textAlignment = .center
+      titleViewLabel.accessibilityTraits = .header
+      hostingController.navigationItem.titleView = titleViewLabel
+    }
 
     // Button text for returning to this view.
     // This button is displayed in book detail view and search view,

--- a/Palace/MyBooks/Views/LoansAndHolds/LoansAndHoldsViewController.swift
+++ b/Palace/MyBooks/Views/LoansAndHolds/LoansAndHoldsViewController.swift
@@ -53,6 +53,8 @@ class LoansAndHoldsViewController: NSObject {
         selection?.selectedSubview = control.selectedSegmentIndex == 0 ? "Loans" : "Holds"
       }, for: .valueChanged)
       hostingController.navigationItem.titleView = segmentedControl
+    } else if #available(iOS 26, *) {
+      // On iPhone iOS 26, use standard nav bar title (no custom label needed)
     } else {
       let titleViewLabel = UILabel()
       titleViewLabel.text = Strings.MyBooksView.loansAndHoldsNavTitle

--- a/Palace/Network/TPPNetworkExecutor.swift
+++ b/Palace/Network/TPPNetworkExecutor.swift
@@ -487,7 +487,14 @@ extension TPPNetworkExecutor {
     
     let link = authentication?.links?.first(where: {$0.rel == "authenticate"})
     //Make a post request to the authentication URL
-    var request = URLRequest(url: URL(string:link!.href)!)
+    guard let href = link?.href, let url = URL(string: href) else {
+      TPPErrorLogger.logError(withCode: .noURL,
+                              summary: "Missing authentication link for token auth",
+                              metadata: ["account": currentAccount?.name ?? "nil"])
+      completion?(nil)
+      return
+    }
+    var request = URLRequest(url: url)
     request.httpMethod = "POST"
     
     //Prints the token

--- a/Palace/Reader2/ReaderPresentation/ReaderModule.swift
+++ b/Palace/Reader2/ReaderPresentation/ReaderModule.swift
@@ -117,7 +117,16 @@ final class ReaderModule: ReaderModuleAPI {
       readerVC.navigationItem.backBarButtonItem = backItem
       readerVC.extendedLayoutIncludesOpaqueBars = true
       readerVC.hidesBottomBarWhenPushed = true
-      navigationController.pushViewController(readerVC, animated: true)
+
+      // On iPad with iOS 18+, the floating tab bar is not hidden by
+      // hidesBottomBarWhenPushed. Present modally to avoid tab bar overlay.
+      if UIDevice.current.userInterfaceIdiom == .pad {
+        let readerNav = UINavigationController(rootViewController: readerVC)
+        readerNav.modalPresentationStyle = .fullScreen
+        navigationController.present(readerNav, animated: true)
+      } else {
+        navigationController.pushViewController(readerVC, animated: true)
+      }
 
     } catch {
       delegate?.presentError(error, from: navigationController)

--- a/Palace/Reader2/UI/TPPBaseReaderViewController.swift
+++ b/Palace/Reader2/UI/TPPBaseReaderViewController.swift
@@ -99,6 +99,15 @@ class TPPBaseReaderViewController: UIViewController, Loggable {
     view.backgroundColor = TPPConfiguration.backgroundColor()
 
     navigationItem.rightBarButtonItems = makeNavigationBarButtons()
+
+    // When presented modally (iPad), add a close button
+    if presentingViewController != nil || navigationController?.presentingViewController != nil {
+      navigationItem.leftBarButtonItem = UIBarButtonItem(
+        barButtonSystemItem: .close,
+        target: self,
+        action: #selector(dismissReader))
+    }
+
     updateNavigationBar(animated: false)
 
     stackView = UIStackView(frame: view.bounds)
@@ -166,6 +175,13 @@ class TPPBaseReaderViewController: UIViewController, Loggable {
     accessibilityToolbar.accessibilityElementsHidden = false
   }
   
+  @objc private func dismissReader() {
+    if let locator = navigator.currentLocation {
+      lastReadPositionPoster.storeReadPosition(locator: locator)
+    }
+    dismiss(animated: true)
+  }
+
   override func viewWillDisappear(_ animated: Bool) {
     super.viewWillDisappear(animated)
     if let locator = navigator.currentLocation {

--- a/Palace/Reader2/UI/TPPEPUBViewController.swift
+++ b/Palace/Reader2/UI/TPPEPUBViewController.swift
@@ -104,9 +104,11 @@ class TPPEPUBViewController: TPPBaseReaderViewController {
 
   override open func viewWillDisappear(_ animated: Bool) {
     super.viewWillDisappear(animated)
-    if let appearance = TPPConfiguration.defaultAppearance() {
-      navigationController?.navigationBar.setAppearance(appearance)
-      navigationController?.navigationBar.forceUpdateAppearance(style: systemUserInterfaceStyle)
+    if #unavailable(iOS 26) {
+      if let appearance = TPPConfiguration.defaultAppearance() {
+        navigationController?.navigationBar.setAppearance(appearance)
+        navigationController?.navigationBar.forceUpdateAppearance(style: systemUserInterfaceStyle)
+      }
     }
 
     navigationController?.navigationBar.tintColor = TPPConfiguration.iconColor()
@@ -173,12 +175,14 @@ extension TPPEPUBViewController: TPPReaderSettingsDelegate {
   /// - Parameter appearance: The appearance.
   internal func setUIColor(for appearance: UserProperty) {
     let colors = TPPAssociatedColors.colors(for: appearance)
-    
+
     navigator.view.backgroundColor = colors.backgroundColor
     view.backgroundColor = colors.backgroundColor
     view.tintColor = colors.textColor
-    navigationController?.navigationBar.setAppearance(TPPConfiguration.appearance(withBackgroundColor: colors.backgroundColor))
-    navigationController?.navigationBar.forceUpdateAppearance(style: colors.navigationColor == .black ? .light : .dark)
+    if #unavailable(iOS 26) {
+      navigationController?.navigationBar.setAppearance(TPPConfiguration.appearance(withBackgroundColor: colors.backgroundColor))
+      navigationController?.navigationBar.forceUpdateAppearance(style: colors.navigationColor == .black ? .light : .dark)
+    }
     navigationController?.navigationBar.tintColor = colors.navigationColor
     tabBarController?.tabBar.tintColor = colors.navigationColor
   }

--- a/Palace/Reader2/UI/TPPEPUBViewController.swift
+++ b/Palace/Reader2/UI/TPPEPUBViewController.swift
@@ -72,8 +72,10 @@ class TPPEPUBViewController: TPPBaseReaderViewController {
     super.willMove(toParent: parent)
 
     // Restore catalog default UI colors
-    navigationController?.navigationBar.barStyle = .default
-    navigationController?.navigationBar.barTintColor = nil
+    if #unavailable(iOS 26) {
+      navigationController?.navigationBar.barStyle = .default
+      navigationController?.navigationBar.barTintColor = nil
+    }
   }
 
   override open func viewWillAppear(_ animated: Bool) {

--- a/Palace/Reader2/UI/TPPReaderPositionsVC.swift
+++ b/Palace/Reader2/UI/TPPReaderPositionsVC.swift
@@ -120,9 +120,11 @@ class TPPReaderPositionsVC: UIViewController, UITableViewDataSource, UITableView
 
     configRefreshControl()
 
-    navigationController?.navigationBar.barStyle = .default
-    navigationController?.navigationBar.isTranslucent = true
-    navigationController?.navigationBar.barTintColor = nil
+    if #unavailable(iOS 26) {
+      navigationController?.navigationBar.barStyle = .default
+      navigationController?.navigationBar.isTranslucent = true
+      navigationController?.navigationBar.barTintColor = nil
+    }
     navigationController?.navigationBar.tintColor = readerColors.tintColor
   }
 

--- a/Palace/Settings/NewSettings/TPPSettingsViewController.swift
+++ b/Palace/Settings/NewSettings/TPPSettingsViewController.swift
@@ -19,11 +19,17 @@ class TPPSettingsViewController: NSObject {
     controller.tabBarItem.imageInsets = UIEdgeInsets(top: 4.0, left: 0.0, bottom: -4.0, right: 0.0)
     controller.navigationItem.backButtonTitle = Strings.Settings.settingsNavTitle
     
-    let titleViewLabel = UILabel()
-    titleViewLabel.text = Strings.Settings.settingsNavTitle
-    titleViewLabel.font = UIFont.palaceFont(ofSize: 16)
-    titleViewLabel.accessibilityTraits = .header
-    controller.navigationItem.titleView = titleViewLabel
+    // On iPad iOS 26+, the floating tab bar already shows the title,
+    // so the extra label is redundant.
+    if #available(iOS 26, *), UIDevice.current.userInterfaceIdiom == .pad {
+      // No titleView needed — tab bar shows the title
+    } else {
+      let titleViewLabel = UILabel()
+      titleViewLabel.text = Strings.Settings.settingsNavTitle
+      titleViewLabel.font = UIFont.palaceFont(ofSize: 16)
+      titleViewLabel.accessibilityTraits = .header
+      controller.navigationItem.titleView = titleViewLabel
+    }
    
     let navigationController = UINavigationController(rootViewController: controller)
     return navigationController

--- a/Palace/Settings/NewSettings/TPPSettingsViewController.swift
+++ b/Palace/Settings/NewSettings/TPPSettingsViewController.swift
@@ -21,8 +21,8 @@ class TPPSettingsViewController: NSObject {
     
     // On iPad iOS 26+, the floating tab bar already shows the title,
     // so the extra label is redundant.
-    if #available(iOS 26, *), UIDevice.current.userInterfaceIdiom == .pad {
-      // No titleView needed — tab bar shows the title
+    if #available(iOS 26, *) {
+      // On iOS 26, use standard nav bar title (no custom label needed)
     } else {
       let titleViewLabel = UILabel()
       titleViewLabel.text = Strings.Settings.settingsNavTitle

--- a/Palace/SignInLogic/PasskeyManager.swift
+++ b/Palace/SignInLogic/PasskeyManager.swift
@@ -213,7 +213,7 @@ class PasskeyManager : NSObject, ASAuthorizationControllerPresentationContextPro
 
     URLSession.shared.dataTask(with: startRequest) { data, response, error in
       print("passkey start error: \(error.debugDescription))")
-      print("passkey start result: \(String(bytes: data!.bytes, encoding: .utf8))")
+      print("passkey start result: \(String(data: data!, encoding: .utf8) ?? "")")
       
       let httpResponse = response as! HTTPURLResponse
 
@@ -291,7 +291,7 @@ class PasskeyManager : NSObject, ASAuthorizationControllerPresentationContextPro
     //print("login content: \(content)")
     URLSession.shared.dataTask(with: finishRequest) { _data,_response,_error in
       print("passkey finish error: \(_error.debugDescription))")
-      print("passkey finish result: \(String(bytes: _data!.bytes, encoding: .utf8))")
+      print("passkey finish result: \(String(data: _data!, encoding: .utf8) ?? "")")
       
       if let httpResponse = _response as? HTTPURLResponse {
         print("passkey status: \(httpResponse.statusCode)")

--- a/Palace/Toast/ToastService.swift
+++ b/Palace/Toast/ToastService.swift
@@ -3,7 +3,6 @@
 //
 
 import SwiftUI
-import SwiftUICore
 
 
 // MARK: - Service for showing toast messages

--- a/Palace/Views/EkirjastoSuomiIdentificationWebView.swift
+++ b/Palace/Views/EkirjastoSuomiIdentificationWebView.swift
@@ -45,8 +45,13 @@ struct SuomiIdentificationWebView: UIViewRepresentable {
     view.configuration.websiteDataStore = WKWebsiteDataStore.nonPersistent()
     let authentication = authenticationDocument?.authentication?.first(where: { $0.type == "http://e-kirjasto.fi/authtype/ekirjasto"})
     let link = authentication?.links?.first(where: {$0.rel == "tunnistus_start"})
-    let start = link
-    var request = URLRequest(url: URL(string: "\(start!.href)&state=app")!)
+    guard let href = link?.href, let url = URL(string: "\(href)&state=app") else {
+      TPPErrorLogger.logError(withCode: .noURL,
+                              summary: "Missing tunnistus_start link for authentication",
+                              metadata: nil)
+      return view
+    }
+    var request = URLRequest(url: url)
     request.addValue("application/json", forHTTPHeaderField: "accept")
     request.cachePolicy = .reloadIgnoringLocalAndRemoteCacheData
     

--- a/scripts/build-3rd-party-dependencies.sh
+++ b/scripts/build-3rd-party-dependencies.sh
@@ -56,7 +56,8 @@ basename "$0"
 
 info "Building 3rd party dependencies..."
 
-(cd readium-sdk; bash MakeHeaders.sh Apple) || fatal "Error making Readium headers" $?
+# NOTE: readium-sdk MakeHeaders.sh removed — old Readium 1 C++ SDK is no longer used.
+# The app uses the modern Readium swift-toolkit (R2) via SPM.
 
 # Rebuild Carthage dependencies
 ./scripts/build-carthage.sh || fatal "Carthage build failed" $?


### PR DESCRIPTION
## Summary

- Migrate project to build with Xcode 26 / iOS 26 SDK
- Adopt Liquid Glass navigation bar and tab bar theming on both iPad and iPhone
- Move the catalog entry point filter (All/eBooks/Audiobooks) into the navigation bar on iPad
- Add top inset for the Magazines web view on iPad iOS 26
- Replace deprecated `UIApplication.shared.windows` and other iOS 26 deprecations
- Fix crash on missing `tunnistus_start` authentication link during token auth

## Known issues

- LCP Test certificate has expired; awaiting EDRLab production liblcp 4.3.0 rebuild (production LCP works fine with 4.1.0)

## Test plan

- [ ] Browse catalog on iPhone and iPad (iOS 26)
- [ ] Verify Liquid Glass nav bar appearance on both devices
- [ ] Verify opaque nav bar on iPhone, transparent on iPad
- [ ] Check section headers scroll with content (not sticky)
- [ ] Test Suomi.fi authentication flow on production
- [ ] Borrow and open an EPUB on production (LCP prod certs work)
- [ ] Verify Magazines tab renders correctly on iPad
- [ ] Test Settings, My Books, and Favorites tab navigation