### PR TITLE
Fix PDF reader on iPad iOS 26

### DIFF
--- a/Palace/Book/UI/BookCell/TPPBookCellDelegate.m
+++ b/Palace/Book/UI/BookCell/TPPBookCellDelegate.m
@@ -188,7 +188,7 @@ static const int kServerUpdateDelay = 15;
       }];
       
       UIViewController *vc = [TPPPDFViewController createWithDocument:document metadata:metadata];
-      [[TPPRootTabBarController sharedController] pushViewController:vc animated:YES];
+      [self presentPDFReader:vc];
     }];
   } else {
     [self presentPDF:book];
@@ -206,11 +206,25 @@ static const int kServerUpdateDelay = 15;
 
   TPPPDFDocumentMetadata *metadata = [[TPPPDFDocumentMetadata alloc] initWith:book.identifier];
   metadata.title = book.title;
-  
+
   TPPPDFDocument *document = [[TPPPDFDocument alloc] initWithData:data];
-  
+
   UIViewController *vc = [TPPPDFViewController createWithDocument:document metadata:metadata];
-  [[TPPRootTabBarController sharedController] pushViewController:vc animated:YES];
+  [self presentPDFReader:vc];
+}
+
+/// Present the PDF reader, mirroring the EPUB reader presentation strategy.
+/// On iPad, the iOS 18+ floating tab bar is not hidden by
+/// hidesBottomBarWhenPushed, so the reader must be presented modally.
+- (void)presentPDFReader:(UIViewController *)vc {
+  TPPRootTabBarController *tabBar = [TPPRootTabBarController sharedController];
+  if (UIDevice.currentDevice.userInterfaceIdiom == UIUserInterfaceIdiomPad) {
+    UINavigationController *nav = [[UINavigationController alloc] initWithRootViewController:vc];
+    nav.modalPresentationStyle = UIModalPresentationFullScreen;
+    [tabBar presentViewController:nav animated:YES completion:nil];
+  } else {
+    [tabBar pushViewController:vc animated:YES];
+  }
 }
 
 - (void)openAudiobook:(TPPBook *)book {

--- a/Palace/PDF/Extensions/View.swift
+++ b/Palace/PDF/Extensions/View.swift
@@ -34,8 +34,13 @@ extension View {
 
   /// Shows the view when `when` condition is `true`
   /// - Parameter when: Condition when the view is visible
+  ///
+  /// When invisible, the view also stops receiving touches — otherwise
+  /// stacked invisible overlays would block taps/swipes on views below
+  /// (observed on iOS 26 with PDFKit's page-view-controller swipes).
   func visible(when: Bool) -> some View {
     opacity(when ? 1 : 0)
+      .allowsHitTesting(when)
   }
   
   /// Minimal size for toolbar buttons

--- a/Palace/PDF/Views/TPPEncryptedPDFView.swift
+++ b/Palace/PDF/Views/TPPEncryptedPDFView.swift
@@ -23,10 +23,6 @@ struct TPPEncryptedPDFView: View {
       TPPEncryptedPDFViewer(encryptedPDF: encryptedPDF, currentPage: $metadata.currentPage, showingDocumentInfo: $showingDocumentInfo)
         .edgesIgnoringSafeArea([.all])
       VStack {
-        if let title = encryptedPDF.title ?? metadata.title {
-          TPPPDFLabel(title)
-            .padding(.top)
-        }
         Spacer()
         TPPPDFLabel("\(metadata.currentPage + 1)/\(encryptedPDF.pageCount)")
         TPPPDFPreviewBar(document: encryptedPDF, currentPage: $metadata.currentPage)
@@ -37,7 +33,9 @@ struct TPPEncryptedPDFView: View {
         // TPPEncryptedPDFPageViewController doesn't receive double tap without this
       }
       .onTapGesture(count: 1) {
-        showingDocumentInfo.toggle()
+        withAnimation(.easeInOut(duration: 0.3)) {
+          showingDocumentInfo.toggle()
+        }
       }
     }
     .navigationBarHidden(!showingDocumentInfo)

--- a/Palace/PDF/Views/TPPPDFDocumentView.swift
+++ b/Palace/PDF/Views/TPPPDFDocumentView.swift
@@ -40,7 +40,9 @@ struct TPPPDFDocumentView: UIViewRepresentable {
         let elementTapped = self.pdfView.areaOfInterest(for: touchPoint)
         // If the tapped element is not interactive, change bar visibility
         if elementTapped.intersection([.linkArea, .controlArea, .popupArea, .textFieldArea]).isEmpty {
-          showingDocumentInfo.toggle()
+          withAnimation(.easeInOut(duration: 0.3)) {
+            showingDocumentInfo.toggle()
+          }
         }
       }
     })
@@ -49,6 +51,9 @@ struct TPPPDFDocumentView: UIViewRepresentable {
       isTracking = value
     }
     
+    // Don't steal touches from PDFKit's UIPageViewController, otherwise
+    // horizontal swipe-to-turn-page stops working on iOS 26.
+    pdfViewGestureRecognizer.cancelsTouchesInView = false
     pdfView.addGestureRecognizer(pdfViewGestureRecognizer)
 
     return pdfView

--- a/Palace/PDF/Views/TPPPDFNavigation.swift
+++ b/Palace/PDF/Views/TPPPDFNavigation.swift
@@ -40,10 +40,9 @@ struct TPPPDFNavigation<Content>: View where Content: View {
   }
   
   @EnvironmentObject var metadata: TPPPDFDocumentMetadata
-  
-  @Environment(\.presentationMode) var presentationMode: Binding<PresentationMode>
-  
+
   @Binding var readerMode: TPPPDFReaderMode
+  var onDismiss: (() -> Void)? = nil
 
   private var isShowingPdfContorls: Bool {
     readerMode == .previews || readerMode == .bookmarks || readerMode == .toc
@@ -62,37 +61,34 @@ struct TPPPDFNavigation<Content>: View where Content: View {
   var leadingItems: some View {
     HStack {
       TPPPDFBackButton {
-        presentationMode.wrappedValue.dismiss()
+        onDismiss?()
       }
-      
-      ZStack(alignment: .leading) {
-        TPPPDFToolbarButton(icon: "list.bullet") {
-          readerMode = TPPPDFReaderModeValues(rawValue: pickerSelection)?.readerMode ?? .previews
-          metadata.fetchBookmarks()
-        }
-        .visible(when: !isShowingPdfContorls)
 
+      if isShowingPdfContorls {
         Picker("", selection: $pickerSelection.onChange(changeReaderMode)) {
           ForEach(TPPPDFReaderModeValues.allValues) { readerModeValue in
             readerModeValue.image
               .tag(readerModeValue.rawValue)
           }
         }
-        .toolbarButtonSize()
         .pickerStyle(.segmented)
-        .visible(when: isShowingPdfContorls)
+        .frame(width: 160)
+      } else {
+        TPPPDFToolbarButton(icon: "list.bullet") {
+          readerMode = TPPPDFReaderModeValues(rawValue: pickerSelection)?.readerMode ?? .previews
+          metadata.fetchBookmarks()
+        }
       }
     }
   }
 
   @ViewBuilder
   var trailingItems: some View {
-    ZStack(alignment: .trailing) {
+    if isShowingPdfContorls {
       TPPPDFToolbarButton(text: Strings.TPPPDFNavigation.resume) {
         readerMode = .reader
       }
-      .visible(when: isShowingPdfContorls)
-
+    } else {
       HStack {
         TPPPDFToolbarButton(icon: "magnifyingglass") {
           readerMode = (readerMode == .search ? .reader : .search)
@@ -105,7 +101,6 @@ struct TPPPDFNavigation<Content>: View where Content: View {
           }
         }
       }
-      .visible(when: !isShowingPdfContorls)
     }
   }
 

--- a/Palace/PDF/Views/TPPPDFReaderView.swift
+++ b/Palace/PDF/Views/TPPPDFReaderView.swift
@@ -20,9 +20,10 @@ struct TPPPDFReaderView: View {
   }
 
   let document: TPPPDFDocument
-  
+  var onDismiss: (() -> Void)? = nil
+
   var body: some View {
-    TPPPDFNavigation(readerMode: $readerMode) { _ in
+    TPPPDFNavigation(readerMode: $readerMode, onDismiss: onDismiss) { _ in
       ZStack {
         documentView
           .onReceive(metadata.$remotePage, perform: showRemotePositionAlert)

--- a/Palace/PDF/Views/TPPPDFView.swift
+++ b/Palace/PDF/Views/TPPPDFView.swift
@@ -30,10 +30,6 @@ struct TPPPDFView: View {
         .edgesIgnoringSafeArea([.all])
 
       VStack {
-        if let title = document.title ?? metadata.title {
-          TPPPDFLabel(title)
-            .padding(.top)
-        }
         Spacer()
         if let pageLabel = document.page(at: metadata.currentPage)?.label, Int(pageLabel) != (metadata.currentPage + 1) {
           TPPPDFLabel("\(pageLabel) (\(metadata.currentPage + 1)/\(document.pageCount))")
@@ -51,15 +47,12 @@ struct TPPPDFView: View {
         }
       }
       .opacity(showingDocumentInfo ? 1 : 0)
-      .contentShape(Rectangle())
+      .allowsHitTesting(showingDocumentInfo)
     }
     .navigationBarHidden(!showingDocumentInfo)
     .onReceive(pageChangePublisher) { value in
       if let pdfView = (value.object as? PDFView), let page = pdfView.currentPage, let pageIndex = pdfView.document?.index(for: page) {
         metadata.currentPage = pageIndex
-        if isTracking {
-            showingDocumentInfo = false
-        }
       }
     }
   }

--- a/Palace/PDF/Views/TPPPDFViewController.swift
+++ b/Palace/PDF/Views/TPPPDFViewController.swift
@@ -15,15 +15,41 @@ fileprivate let supportedEncryptedDataSize = 200 * 1024 * 1024
 class TPPPDFViewController: NSObject {
 
   @objc static func create(document: TPPPDFDocument, metadata: TPPPDFDocumentMetadata) -> UIViewController {
-    var controller: UIViewController!
+    // Resolve the effective document (decrypt if needed) before constructing the host.
+    let readerDocument: TPPPDFDocument
     if document.isEncrypted && document.data.count < supportedEncryptedDataSize {
       let data = document.decrypt(data: document.data, start: 0, end: UInt(document.data.count))
-      controller = UIHostingController(rootView: TPPPDFReaderView(document: TPPPDFDocument(data: data)).environmentObject(metadata))
+      readerDocument = TPPPDFDocument(data: data)
     } else {
-      controller = UIHostingController(rootView: TPPPDFReaderView(document: document).environmentObject(metadata))
+      readerDocument = document
     }
-    controller.title = ""
+
+    // Create the host first with a placeholder rootView so we can capture it
+    // weakly in the dismiss closure. `@Environment(\.dismiss)` does not bridge
+    // across the UIKit modal presentation used on iPad, so we dismiss/pop
+    // explicitly based on where the host ended up in the VC hierarchy.
+    let controller = UIHostingController(rootView: AnyView(EmptyView()))
+    controller.title = metadata.title ?? ""
     controller.hidesBottomBarWhenPushed = true
+
+    let onDismiss: () -> Void = { [weak controller] in
+      guard let controller = controller else { return }
+      if let nav = controller.navigationController,
+         nav.viewControllers.first !== controller {
+        // Pushed onto an existing nav stack (iPhone path)
+        nav.popViewController(animated: true)
+      } else if let nav = controller.navigationController {
+        // Root of a modally-presented nav controller (iPad path)
+        nav.dismiss(animated: true)
+      } else {
+        controller.dismiss(animated: true)
+      }
+    }
+
+    controller.rootView = AnyView(
+      TPPPDFReaderView(document: readerDocument, onDismiss: onDismiss)
+        .environmentObject(metadata)
+    )
     return controller
   }
 


### PR DESCRIPTION
**What's this do?**
Follow-up fixes for the PDF reader on iPad iOS 26 after the Liquid Glass migration (#160):
  - iPad catalog's floating tab bar overlayed the reader → reader is now presented modally on iPad (pushed on iPhone as before)
  - In-content overlay showed PDFKit's embedded (often meaningless) document title, e.g. "s.pdf" → dropped; book's real title shows in the nav bar instead
  - Tap no longer toggled chrome and horizontal swipe didn't turn pages → caused by invisible SwiftUI overlays blocking hit-testing and a custom UIGestureRecognizer stealing touches from PDFKit's internal
  UIPageViewController. Both fixed.
  - Chrome auto-hid while swiping → now stays visible during swipe, matching the EPUB reader
  - Back button did nothing on iPad → replaced @Environment(\.dismiss) (which doesn't bridge the UIKit modal boundary) with a dismiss closure injected from the host controller that pops or dismisses depending on
  how the reader was presented
  - Segmented picker (previews/TOC/bookmarks) was squashed next to the back button in controls mode → proper width, back button stops fighting it for space
  - Chrome toggle is now animated (0.3s ease-in-out), matching the EPUB reader

**Why are we doing this? (w/ Notion link if applicable)**
The PDF reader's behavior on iPad iOS 26 regressed after #160. These are small, targeted fixes to restore expected behavior and bring the PDF reader to parity with the EPUB reader's interaction model.

**How should this be tested? / Do these changes have associated tests?**
Manual testing on iPad (iOS 26) and iPhone by opening an LCP-protected PDF from My Books:

1. iPad: reader opens full-screen with no floating catalog tab bar visible
2. Nav bar title shows the actual book title (not "s.pdf" or a filename)
3. Horizontal swipe turns pages
4. Single tap toggles the top nav bar and bottom thumbnail strip with a fade
5. Chrome stays visible while swiping through pages
6. Back button dismisses the reader
7. Tapping the list icon on the left shows TOC/previews/bookmarks controls, not squashed
8. iPhone: reader pushes onto the nav stack; back button pops it

No automated tests — UI/gesture behavior validated manually in simulator.

**Dependencies for merging? Releasing to production?**
None. Changes are isolated to the PDF reader (Palace/PDF/… + the IAP/open-book delegate dispatch).

**Does this include changes that require a new Palace build for QA?**
No Palace-side changes.

**Has the application documentation been updated for these changes?**
Not applicable — internal behavior fixes, no user-facing docs affected.

**Did someone actually run this code to verify it works?**
Yes. Verified on iPad Air 11" simulator (iOS 26.4), iPad A16 simulator (iOS 18.6) and iPhone 17 Pro simulator (iOS 26.4) with an LCP-protected PDF ("Ympäristön tila ja suojelu Suomessa").

**Have the Transifex translators been notified?**
No user-facing string changes.

**AI was used during the process and I have described how.**
- [x] AI was used to diagnose the issues and propose edits, which were reviewed, applied, and tested on simulator by human before committing anything.
