### PR TITLE
EKIRJASTO-DEPENDABOT Bump MrSquaare/ssh-setup-action from 3.1.1 to 4.0.0

### DIFF
--- a/.github/workflows/ios-main.yml
+++ b/.github/workflows/ios-main.yml
@@ -36,7 +36,7 @@ jobs:
         run: scripts/show-ci-info.sh
 
       - name: SSH setup (for cloning ekirjasto-ios-keys through Fastlane match)
-        uses: MrSquaare/ssh-setup-action@v3.1.1
+        uses: MrSquaare/ssh-setup-action@v4.0.0
         with:
           private-key-name: ekirjasto-ci-ed25519
           private-key: ${{ secrets.SSH_PRIVATE_KEY }}

--- a/.github/workflows/ios-pr.yml
+++ b/.github/workflows/ios-pr.yml
@@ -36,7 +36,7 @@ jobs:
         run: scripts/show-ci-info.sh
 
       - name: SSH setup (for cloning ekirjasto-ios-keys through Fastlane match)
-        uses: MrSquaare/ssh-setup-action@v3.1.1
+        uses: MrSquaare/ssh-setup-action@v4.0.0
         with:
           private-key-name: ekirjasto-ci-ed25519
           private-key: ${{ secrets.SSH_PRIVATE_KEY }}

--- a/.github/workflows/ios-release.yml
+++ b/.github/workflows/ios-release.yml
@@ -36,7 +36,7 @@ jobs:
         run: scripts/show-ci-info.sh
 
       - name: SSH setup (for cloning ekirjasto-ios-keys through Fastlane match)
-        uses: MrSquaare/ssh-setup-action@v3.1.1
+        uses: MrSquaare/ssh-setup-action@v4.0.0
         with:
           private-key-name: ekirjasto-ci-ed25519
           private-key: ${{ secrets.SSH_PRIVATE_KEY }}


### PR DESCRIPTION
## What's this do?
- Bumps [MrSquaare/ssh-setup-action](https://github.com/mrsquaare/ssh-setup-action) from 3.1.1 to 4.0.0.

## Why are we doing this?
- https://github.com/NatLibFi/ekirjasto-ios-core/pull/161
